### PR TITLE
Remove Total Playtime

### DIFF
--- a/templates/profile.html
+++ b/templates/profile.html
@@ -281,10 +281,6 @@
 												<td class="right aligned">{{ playtimeConv .playtime }}</td>
 											</tr>
 											<tr>
-												<td><b>{{ $global.T "Total playtime" }}</b></td>
-												<td class="right aligned">{{ playtimeConv .total_playtime }}</td>
-											</tr>
-											<tr>
 												<td><b>{{ $global.T "Replays watched" }}</b></td>
 												<td class="right aligned">{{ humanize .replays_watched }}</td>
 											</tr>


### PR DESCRIPTION
Total Playtime has been broken for a while + is not really useful anymore, only Playtime will be visible on profiles now. This will be gamemode specific.

Links to https://github.com/osuAkatsuki/akatsuki-api/pull/18