### PR TITLE
fix: update dev privileges

### DIFF
--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -69,7 +69,7 @@
               {{ $community := has .privileges 1036539 }}
               {{ $accounts := has .privileges 4283 }}
               {{ $product := has .privileges 1046779 }}
-              {{ $dev := has .privileges 3145723 }}
+              {{ $dev := has .privileges 2354715 }}
               {{ $event := has .privileges 2097155 }}
               {{ $nominator := has .privileges 267 }}
               {{ $scorewatcher := false }}


### PR DESCRIPTION
dev privilege group changed because there was no differentiation between dev and product manager (and dev had some unneeded privileges) so need this update to reflect