### PR TITLE
fix: profile, team & donation page 📜

### DIFF
--- a/web/static/css/pages/profile.css
+++ b/web/static/css/pages/profile.css
@@ -1,12 +1,14 @@
 :root {
-  --colour-community: #ff695e;
-  --colour-accounts: #ff4404;
-  --colour-product: #b02025;
+  --colour-community: #ee4343;
+  --colour-accounts: #ff7746;
+  --colour-product: #1d7cd5;
+  --colour-support: #ffb523;
   --colour-dev: #66a9f7;
-  --colour-event: #ffd50a;
+  --colour-event: #d6ca63;
+  --colour-nqa: #a291fb;
   --colour-nominator: #a333c8;
   --colour-scorewatcher:#e07fc4;
-  --colour-supporter: #5fd5eb;
+  --colour-donor: #5fd5eb;
   --colour-premium: #fff176;
 }
 
@@ -230,12 +232,20 @@
   color: var(--colour-product);
 }
 
+.label-support {
+  color: var(--colour-support);
+}
+
 .label-dev {
   color: var(--colour-dev);
 }
 
 .label-event {
   color: var(--colour-event);
+}
+
+.label-nqa {
+  color: var(--colour-nqa);
 }
 
 .label-nominator {
@@ -246,8 +256,8 @@
   color: var(--colour-scorewatcher);
 }
 
-.label-supporter {
-  color: var(--colour-supporter);
+.label-donor {
+  color: var(--colour-donor);
 }
 
 .label-premium {

--- a/web/templates/donate.html
+++ b/web/templates/donate.html
@@ -33,7 +33,7 @@ BannerType=1
         </h1>
         <hr />
         <p>
-          {{ $.T "We have two 'tiers' of supporter levels for akatsuki; both loaded with perks for us to show our appreciation for your support <3." }}
+          {{ $.T "We have two 'tiers' of supporter levels for Akatsuki; both loaded with perks for us to show our appreciation for your support <3." }}
         </p>
         <h3 class="ui center" style="text-align: center;">
           {{ $.T "Feel free to check out the pages below to explore the perks." }}

--- a/web/templates/patcherdl.html
+++ b/web/templates/patcherdl.html
@@ -43,7 +43,7 @@ BannerType=1
           Download
         </h4>
         <h5>
-          Akatsuki patcher is a single executable and requires no manual client modification!
+          Akatsuki Patcher is a single executable and requires no manual client modification!
         </h5>
         {{ if not ($downEnabled.value_int.Bool) }}
         <a class="ui green button disabled" href="#">

--- a/web/templates/premium.html
+++ b/web/templates/premium.html
@@ -165,10 +165,10 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
         </h4>
         <center>
           <p>
-            {{ $.T "Disclaimer: Unfortunately we do not yet process payments automatically. We will try to distribute the premium role to you as soon as possible, but please be aware it depends on the availability of our limited staffing." | html }}
+            {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please open a ticket in our <a href='/discord'>Discord server</a>!" | html }}
             <br />
             <br />
-            {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's rules." | html }}
+            {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's Rules." | html }}
           </p>
         </center>
       {{ else }}

--- a/web/templates/premium.html
+++ b/web/templates/premium.html
@@ -165,16 +165,16 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
         </h4>
         <center>
           <p>
-            {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please open a ticket in our <a href='/discord'>Discord server</a>!" | html }}
+            {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please <b>open a ticket</b> in our <a href='/discord'>Discord server</a>!" | html }}
             <br />
             <br />
-            {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's Rules." | html }}
+            {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from <a href='/doc/tos'>Akatsuki's Rules</a>." | html }}
           </p>
         </center>
       {{ else }}
         <div class="ui divider"></div>
         <h1 class="ui center aligned header">
-          {{ $.T "Please log in before purchasing premium." }}
+          {{ $.T "Please log in before purchasing Premium." }}
         </h1>
       {{ end }}
     </div>

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -63,19 +63,24 @@
             <div class="profile-info">
               {{ $user := . }}
 
-              {{ $supporter := has .privileges 7 }}
+              {{ $donor := has .privileges 7 }}
               {{ $premium := has .privileges 8388615 }}
 
-              {{ $community := has .privileges 1036539 }}
-              {{ $accounts := has .privileges 4283 }}
-              {{ $product := has .privileges 7340027 }}
-              {{ $dev := has .privileges 2354715 }}
-              {{ $event := has .privileges 2097155 }}
-              {{ $nominator := has .privileges 259 }}
+              {{ $product := has .privileges 9435391 }}
+              {{ $community := has .privileges 9425151 }}
+              {{ $accounts := has .privileges 8392895 }}
+              {{ $support := has .privileges 9175111 }}
+              {{ $dev := has .privileges 10743327 }}
+              {{ $nqa := false }}
+              {{ $nominator := has .privileges 8388871 }}
+              {{ $event := has .privileges 10485767 }}
               {{ $scorewatcher := false }}
               {{ range .badges }}
                 {{ if eq .id (float 86) }}
                   {{ $scorewatcher = true }}
+                {{ end }}
+                {{ if eq .id (float 100) }}
+                  {{ $nqa = true }}
                 {{ end }}
               {{ end }}
 
@@ -106,21 +111,27 @@
                       {{ else if $accounts }}
                         <div class="profile-label label-accounts label-full">ACCOUNTS MANAGER</div>
                         <div class="profile-label label-accounts label-mobile">AMT</div>
+                      {{ else if $support }}
+                        <div class="profile-label label-support label-full">COMMUNITY SUPPORT</div>
+                        <div class="profile-label label-support label-mobile">CS</div>
                       {{ else if $event }}
                         <div class="profile-label label-event label-full">EVENT MANAGER</div>
                         <div class="profile-label label-event label-mobile">EMT</div>
                       {{ else if $nominator }}
                         <div class="profile-label label-nominator label-full">BEATMAP NOMINATOR</div>
                         <div class="profile-label label-nominator label-mobile">BN</div>
+                      {{ else if $nqa }}
+                        <div class="profile-label label-nqa label-full">NOMINATION QUALITY ASSURANCE</div>
+                        <div class="profile-label label-nqa label-mobile">NQA</div>
                       {{ else if $scorewatcher }}
                         <div class="profile-label label-scorewatcher label-full">SOCIAL MEDIA MANAGER</div>
                         <div class="profile-label label-scorewatcher label-mobile">SW</div>
                       {{ else if $premium }}
-                        <div class="profile-label label-premium label-full"><span>PREMIUM <i class="fa-solid fa-heart label-icon"></i></span></div>
+                        <div class="profile-label label-premium label-full">PREMIUM</div>
                         <div class="profile-label label-premium label-mobile"><span><i class="fa-solid fa-heart label-icon"></i></span></div>
-                      {{ else if $supporter }}
-                        <div class="profile-label label-supporter label-full"><span>SUPPORTER <i class="fa-solid fa-heart label-icon"></i></span></span></div>
-                        <div class="profile-label label-supporter label-mobile"><span><i class="fa-solid fa-heart label-icon"></i></span></div>
+                      {{ else if $donor }}
+                        <div class="profile-label label-donor label-full">SUPPORTER</div>
+                        <div class="profile-label label-donor label-mobile"><span><i class="fa-solid fa-heart label-icon"></i></span></div>
                       {{ end }}
 
                     </div>

--- a/web/templates/register/elmo.html
+++ b/web/templates/register/elmo.html
@@ -36,7 +36,9 @@ HeadingOnRight=true
         </p>
         <p style="margin-bottom:40px;">
           <a href="/register?stopsign=1" class="camouflaged">
-            {{ .T "If you truly have understood what's written above and you have understood that creating a multiaccount will lead to a restriction on your main account, you can click here and you'll be brought to the sign up page." }}
+            <b>
+              {{ .T "If you truly have understood what's written above and you have understood that creating a multiaccount will lead to a restriction on your main account, you can click here and you'll be brought to the sign up page." }}
+            </b>
           </a>
         </p>
       </div>

--- a/web/templates/support.html
+++ b/web/templates/support.html
@@ -176,10 +176,10 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
           </h4>
           <center>
             <p>
-              {{ $.T "Disclaimer: Unfortunately we do not yet process payments automatically. We will try to distribute the supporter role to you as soon as possible, but please be aware it depends on the availability of our limited staffing." | html }}
+              {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please open a ticket in our <a href='/discord'>Discord server</a>!" | html }}
               <br />
               <br />
-              {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's rules." | html }}
+              {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's Rules." | html }}
             </p>
           </center>
         {{ else }}

--- a/web/templates/support.html
+++ b/web/templates/support.html
@@ -176,10 +176,10 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
           </h4>
           <center>
             <p>
-              {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please open a ticket in our <a href='/discord'>Discord server</a>!" | html }}
+              {{ $.T "We are now processing payments automatically & your perks should be distributed as soon as possible. If you do run into any trouble, please <b>open a ticket</b> in our <a href='/discord'>Discord server</a>!" | html }}
               <br />
               <br />
-              {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from Akatsuki's Rules." | html }}
+              {{ $.T "Disclaimer: Donations are <b>non-refundable</b>, and do not exempt you from <a href='/doc/tos'>Akatsuki's Rules</a>." | html }}
             </p>
           </center>
         {{ else }}

--- a/web/templates/team.html
+++ b/web/templates/team.html
@@ -49,11 +49,11 @@ BannerType=1
         {{ template "users" (.Get "badges/members?id=%d" 32) }}
       </div>
       <div class="ui center aligned segment">
-        <h1 class="ui heading">{{ .T "Event Management Team" }}</h1>
+        <h1 class="ui heading">{{ .T "Community Support Team" }}</h1>
         <p>
-          {{ .T "Responsible for hosting events such as competitions and tournaments, keeping the community thriving." }}
+          {{ .T "Responsible for taking care of players help when needed." }}
         </p>
-        {{ template "users" (.Get "badges/members?id=%d" 78) }}
+        {{ template "users" (.Get "badges/members?id=%d" 99) }}
       </div>
       <div class="ui center aligned segment">
         <h1 class="ui heading">{{ .T "Beatmap Nomination Team" }}</h1>
@@ -105,7 +105,7 @@ BannerType=1
             {{ .T "<b><a href='https://ripple.moe'>Ripple</a></b>, for a stable base to build off of - we would not exist without your work." | html }}
           </li>
           <li>
-            {{ .T "<b><a href='https://akatsuki.gg/u/1000'>rumoi</a></b>, for his work on <a href='https://github.com/rumoi/ruri'>ruri</a>, and our anticheat." | html }}
+            {{ .T "<b><a href='https://akatsuki.gg/u/1003'>rumoi</a></b>, for his work on <a href='https://github.com/rumoi/ruri'>ruri</a>, and our anticheat." | html }}
           </li>
           <li>
             {{ .T "<b><a href='https://akatsuki.gg/u/1776'>Mempler</a></b>, for <b><a href='https://pisstau.be'>pisstau.be</a></b>, and for taking care of the server." | html }}


### PR DESCRIPTION
# Profile Page
- Renamed `supporter` to `donor` to avoid it being mistaken for Community Support (`support`)
- Added profile label for NQA & CS team.
- We're now using `#1d7cd5` for PMT since it's the main blue color in our logo and others have their respective color changed to a custom one to avoid being mistaken for custom badges - thanks to lenforiee's https://github.com/osuAkatsuki/hanayo/pull/102
- Updated privileges weights for profile page with current values matching each groups.
- Replaced "Event Management Team" with "Community Support Team" as we don't have events running right now.

# Registration Page
- Bolded the very important text that everyone seems to skip for some reason :(

# Donation Page
- Changed the disclaimer text since we now have `payments-service`.