### PR TITLE
Fix donor gifting & ensure target user exists

### DIFF
--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -534,6 +534,23 @@ var singlePageSnippets = {
     $("#username-input").on("input", function () {
       $("#ipn-username").attr("value", "username=" + $(this).val());
     });
+    // hook submit button
+    $("paypal-form").on("submit", function (e) {
+      api(
+        "/users/lookup",
+        { name: $("#username-input").val() },
+        null,
+        function () {
+          showMessage(
+            "error",
+            "The username you inputted does not seem to exist in our systems. " +
+              "Please check their username and ensure that it is correct."
+          );
+          e.preventDefault();
+        },
+        false
+      );
+    });
   },
 
   "/premium": function () {

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -787,7 +787,7 @@ $(document).ready(function () {
       "users/whatid",
       { name: $("#username-input").val() },
       function (data) {
-        $("form>input[name='custom']").attr("value", data.id);
+        $("form>input[name='custom']").attr("value", `userid=${data.id}`);
         le.off("submit").trigger("submit");
       },
       function (data) {

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -531,10 +531,7 @@ var singlePageSnippets = {
         $("#paypal-amt").val(priceEUR.toFixed(2));
       });
     });
-    $("#username-input").on("input", function () {
-      $("#ipn-username").attr("value", "username=" + $(this).val());
-    });
-    // hook submit button
+    // hook submit button to handle validation of username input
     $("#paypal-form").on("submit", function (e) {
       const le = $(this);
       e.preventDefault();

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -539,10 +539,10 @@ var singlePageSnippets = {
       api(
         "users/whatid",
         { name: $("#username-input").val() },
-        function (data) {
+        (data) => {
           $("form>input[name='custom']").attr("value", data.id);
         },
-        function (data) {
+        (data) => {
           showMessage(
             "error",
             "The username you inputted does not seem to exist in our systems. " +

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -537,11 +537,10 @@ var singlePageSnippets = {
     // hook submit button
     $("paypal-form").on("submit", function (e) {
       api(
-        "/users/lookup",
+        "users/whatid",
         { name: $("#username-input").val() },
         function (data) {
-          console.log("le data", data);
-          $("form>input[name='custom']").attr("value", "test");
+          $("form>input[name='custom']").attr("value", data.id);
         },
         function (data) {
           showMessage(

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -531,27 +531,6 @@ var singlePageSnippets = {
         $("#paypal-amt").val(priceEUR.toFixed(2));
       });
     });
-    // hook submit button to handle validation of username input
-    $("#paypal-form").on("submit", function (e) {
-      const le = $(this);
-      e.preventDefault();
-      api(
-        "users/whatid",
-        { name: $("#username-input").val() },
-        function (data) {
-          $("form>input[name='custom']").attr("value", data.id);
-          le.off("submit").trigger("submit");
-        },
-        function (data) {
-          showMessage(
-            "error",
-            "The username you inputted does not seem to exist in our systems. " +
-              "Please check their username and ensure that it is correct."
-          );
-        },
-        false
-      );
-    });
   },
 
   "/premium": function () {
@@ -796,6 +775,30 @@ $(document).ready(function () {
     var lang = $(this).data("lang");
     document.cookie = "language=" + lang + ";path=/;max-age=31536000";
     window.location.reload();
+  });
+
+  // hook submit button to handle validation of username input
+  // on donation pages. This code functions both for the /support
+  // as well as the /premium page.
+  $("#paypal-form").on("submit", function (e) {
+    const le = $(this);
+    e.preventDefault();
+    api(
+      "users/whatid",
+      { name: $("#username-input").val() },
+      function (data) {
+        $("form>input[name='custom']").attr("value", data.id);
+        le.off("submit").trigger("submit");
+      },
+      function (data) {
+        showMessage(
+          "error",
+          "The username you inputted does not seem to exist in our systems. " +
+            "Please check their username and ensure that it is correct."
+        );
+      },
+      false
+    );
   });
 });
 

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -543,7 +543,7 @@ var singlePageSnippets = {
         { name: $("#username-input").val() },
         function (data) {
           $("form>input[name='custom']").attr("value", data.id);
-          le.off('submit').trigger('submit')
+          le.off("submit").trigger("submit");
         },
         function (data) {
           showMessage(

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -539,10 +539,10 @@ var singlePageSnippets = {
       api(
         "users/whatid",
         { name: $("#username-input").val() },
-        (data) => {
+        function (data) {
           $("form>input[name='custom']").attr("value", data.id);
         },
-        (data) => {
+        function (data) {
           showMessage(
             "error",
             "The username you inputted does not seem to exist in our systems. " +

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -536,13 +536,14 @@ var singlePageSnippets = {
     });
     // hook submit button
     $("#paypal-form").on("submit", function (e) {
+      const le = $(this);
       e.preventDefault();
       api(
         "users/whatid",
         { name: $("#username-input").val() },
         function (data) {
           $("form>input[name='custom']").attr("value", data.id);
-          $(this).off("submit").trigger("submit");
+          le.off('submit').trigger('submit')
         },
         function (data) {
           showMessage(

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -546,7 +546,6 @@ var singlePageSnippets = {
     });
     var rates = {};
     var us = sl.noUiSlider;
-    var doneOne = false;
     $.getJSON("/donate/rates", function (data) {
       rates = data;
       us.on("update", function () {

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -542,7 +542,7 @@ var singlePageSnippets = {
         { name: $("#username-input").val() },
         function (data) {
           $("form>input[name='custom']").attr("value", data.id);
-          $(this).off('submit').trigger('submit')
+          $(this).off("submit").trigger("submit");
         },
         function (data) {
           showMessage(

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -535,7 +535,7 @@ var singlePageSnippets = {
       $("#ipn-username").attr("value", "username=" + $(this).val());
     });
     // hook submit button
-    $("paypal-form").on("submit", function (e) {
+    $("#paypal-form").on("submit", function (e) {
       api(
         "users/whatid",
         { name: $("#username-input").val() },

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -536,11 +536,13 @@ var singlePageSnippets = {
     });
     // hook submit button
     $("#paypal-form").on("submit", function (e) {
+      e.preventDefault();
       api(
         "users/whatid",
         { name: $("#username-input").val() },
         function (data) {
           $("form>input[name='custom']").attr("value", data.id);
+          $(this).off('submit').trigger('submit')
         },
         function (data) {
           showMessage(
@@ -548,7 +550,6 @@ var singlePageSnippets = {
             "The username you inputted does not seem to exist in our systems. " +
               "Please check their username and ensure that it is correct."
           );
-          e.preventDefault();
         },
         false
       );

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -539,8 +539,11 @@ var singlePageSnippets = {
       api(
         "/users/lookup",
         { name: $("#username-input").val() },
-        null,
-        function () {
+        function (data) {
+          console.log("le data", data);
+          $("form>input[name='custom']").attr("value", "test");
+        },
+        function (data) {
           showMessage(
             "error",
             "The username you inputted does not seem to exist in our systems. " +

--- a/web/static/js/akatsuki_src.js
+++ b/web/static/js/akatsuki_src.js
@@ -792,7 +792,7 @@ $(document).ready(function () {
       function (data) {
         showMessage(
           "error",
-          "The username you inputted does not seem to exist in our systems. " +
+          "The username you input does not seem to exist in our systems. " +
             "Please check their username and ensure that it is correct."
         );
       },

--- a/web/templates/premium.html
+++ b/web/templates/premium.html
@@ -102,6 +102,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
               {{ $.T "PayPal" }}
             </h2>
             <form
+              id="paypal-form"
               action="https://www.paypal.com/cgi-bin/webscr"
               method="post"
               target="_self"
@@ -142,6 +143,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
                   {{ $.T "User:" }}
                 </div>
                 <input
+                  id="username-input"
                   name="os1"
                   type="text"
                   placeholder="{{ $.T "User" }}"

--- a/web/templates/support.html
+++ b/web/templates/support.html
@@ -114,6 +114,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
                 {{ $.T "PayPal" }}
               </h2>
               <form
+                id="paypal-form"
                 action="https://www.paypal.com/cgi-bin/webscr"
                 method="post"
                 target="_self"
@@ -154,6 +155,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/noUiSlider/9.0.0/nouislider.
                     {{ $.T "User:" }}
                   </div>
                   <input
+                    id="username-input"
                     name="os1"
                     type="text"
                     placeholder="{{ $.T "User" }}"


### PR DESCRIPTION
Currently, the supporter page displays a username input box to allow donation for any arbitrary user, however, when sending the request to paypal, it always attaches the user id of the authenticated user.

To remedy this and to improve the experience for our users, this PR attempts to ensure that the correct user is attributed to the donation, and also that it is not possible to accidentally make a payment for a user who does not exist.