### PR TITLE
Unspecialise cheesegull logic

### DIFF
--- a/app/usecases/beatmaps/beatmaps.go
+++ b/app/usecases/beatmaps/beatmaps.go
@@ -40,30 +40,10 @@ type BeatmapSet struct {
 	Creator          string
 	Source           string
 	Tags             string
-	HasVideo         int // bool in cheesegull
+	HasVideo         bool
 	Genre            int
 	Language         int
 	Favourites       int
-}
-
-func GetBeatmapSetDataFromDirectAPI(b string) (bset BeatmapSet, err error) {
-	settings := settingsState.GetSettings()
-	resp, err := http.Get(settings.BEATMAP_MIRROR_API_URL + "/b/" + b + "?full")
-	if err != nil {
-		return bset, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return bset, err
-	}
-
-	err = json.Unmarshal(body, &bset)
-	if err != nil {
-		return bset, err
-	}
-
-	return bset, nil
 }
 
 func GetBeatmapData(b string) (beatmap Beatmap, err error) {


### PR DESCRIPTION
In short - I hate beatmap mirrors.

In long, `HasVideo` should've always been a `bool` as per Cheesegull format and *most* beatmap mirrors. At some point we were using `osu.direct` which wasn't following this so we changed it. Since we have `BeatmapsService` now I'm looking to un-fuck most of these annoying things into something more consistent/standardised. Eventually that means we can get rid of Cheesegull finally but I'm avoiding potential damage for now.

This is a patch for https://github.com/osuAkatsuki/BeatmapsService/commit/528ab8ac6cb43c78536a0114b0c072ef08ebfe1e, which won't be deployed until this is in.