### PR TITLE
Remove unused queries from navbar

### DIFF
--- a/web/templates/navbar.html
+++ b/web/templates/navbar.html
@@ -1,10 +1,6 @@
 {{ define "navbar" }}
   {{ $isRAP   := and (hasAdmin .Context.User.Privileges) (isRAP .Path) }}
   {{ $isAdmin := hasAdmin .Context.User.Privileges }}
-
-  {{ $ccEnabled := qb "SELECT 1 FROM system_settings WHERE name = 'ccreation_enabled' AND value_int = 1 LIMIT 1" }}
-  {{ $isClan := qb "SELECT 1 FROM users WHERE id = ? AND clan_id <> 0" .Context.User.ID }}
-  {{ $clanLeader := qb "SELECT 1 FROM clans WHERE owner = ? LIMIT 1" .Context.User.ID }}
   <div
     class="ui secondary fixed-height white background main menu no margin bottom{{ if .DisableHH }}
       dropped


### PR DESCRIPTION
Identified from datadog analysis: https://app.datadoghq.com/logs?query=service%3Amysql-production&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=paused&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&view=spans&viz=pattern&x_missing=true%2Ctrue&from_ts=1718783549722&to_ts=1718783654233&live=false