### PR TITLE
Refactor to ip-api.com to avoid ip.zxq.co errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ MAILGUN_FROM="Akatsuki" <noreply@akatsuki.pw>
 RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=
 
-IP_LOOKUP_URL=https://ip.zxq.co
+IP_LOOKUP_URL=http://ip-api.com
 
 PAYPAL_EMAIL_ADDRESS=
 

--- a/app/usecases/user/user.go
+++ b/app/usecases/user/user.go
@@ -107,11 +107,10 @@ func SetCountry(c *gin.Context, userID int) error {
 	}
 	geolocation := Geolocation{}
 	json.NewDecoder(resp.Body).Decode(&geolocation)
-	country := strings.TrimSpace(geolocation.CountryCode)
-	if country == "" || len(country) != 2 {
+	if geolocation.CountryCode == "" || len(geolocation.CountryCode) != 2 {
 		return nil
 	}
-	services.DB.Exec("UPDATE users SET country = ? WHERE id = ?", country, userID)
+	services.DB.Exec("UPDATE users SET country = ? WHERE id = ?", geolocation.CountryCode, userID)
 	return nil
 }
 

--- a/app/usecases/user/user.go
+++ b/app/usecases/user/user.go
@@ -102,13 +102,13 @@ func SetCountry(c *gin.Context, userID int) error {
 	settings := settingsState.GetSettings()
 	resp, err := http.Get(settings.IP_LOOKUP_URL + "/json/" + su.ClientIP(c))
 	if err != nil {
-		slog.Error("error", "Could not resolve country from ip!", err.Error())
+		slog.ErrorContext(c, "error", "Could not resolve country from ip!", err.Error())
 		return err
 	}
 	geolocation := Geolocation{}
 	json.NewDecoder(resp.Body).Decode(&geolocation)
 	if geolocation.CountryCode == "" || len(geolocation.CountryCode) != 2 {
-		slog.Error("Unknown countryCode format from ip-api.com", "code", geolocation.CountryCode)
+		slog.ErrorContext(c, "Unknown countryCode format from ip-api.com", "code", geolocation.CountryCode)
 		return nil
 	}
 	services.DB.Exec("UPDATE users SET country = ? WHERE id = ?", geolocation.CountryCode, userID)

--- a/app/usecases/user/user.go
+++ b/app/usecases/user/user.go
@@ -108,6 +108,7 @@ func SetCountry(c *gin.Context, userID int) error {
 	geolocation := Geolocation{}
 	json.NewDecoder(resp.Body).Decode(&geolocation)
 	if geolocation.CountryCode == "" || len(geolocation.CountryCode) != 2 {
+		slog.Error("Unknown countryCode format from ip-api.com", "code", geolocation.CountryCode)
 		return nil
 	}
 	services.DB.Exec("UPDATE users SET country = ? WHERE id = ?", geolocation.CountryCode, userID)


### PR DESCRIPTION
Related logs: https://app.datadoghq.com/logs?query=service%3Ahanayo%20status%3Aerror%20error%20-01%20-context%20-comparing%20-an%20-3988%20-sql&agg_m=count&agg_m_source=base&agg_q=status%2Cservice&agg_q_source=base%2Cbase&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&sort_m=%2C&sort_m_source=%2C&sort_t=%2C&storage=hot&stream_sort=desc&top_n=10%2C10&top_o=top%2Ctop&viz=stream&x_missing=true%2Ctrue&from_ts=1719142949020&to_ts=1719747749020&live=true