### PR TITLE
Add content hashing for static assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ team.json
 .env
 web/static/css
 web/static/js
+web/static/manifest.json

--- a/web/gulpfile.js
+++ b/web/gulpfile.js
@@ -1,16 +1,16 @@
 import gulp from "gulp";
-import { src, dest, watch } from "gulp";
+import { src, dest, watch, series, parallel } from "gulp";
 import babel from "gulp-babel";
 import concat from "gulp-concat";
 import uglify from "gulp-uglify";
 import rename from "gulp-rename";
 import cleanCSS from "gulp-clean-css";
+import rev from "gulp-rev";
 import { deleteAsync } from "del";
+import { writeFileSync, existsSync, readFileSync, mkdirSync } from "fs";
 
 var paths = {
   styles: {
-    // TODO: add src for semantic-ui
-    //       once we move all changes to akatsuki.css
     src: "src/css/**/*.css",
     dest: "static/css/",
   },
@@ -20,7 +20,6 @@ var paths = {
   },
   dist: {
     src: [
-      // TODO: add src for semantic-ui
       "node_modules/jquery/dist/jquery.min.js",
       "node_modules/timeago/jquery.timeago.js",
       "node_modules/i18next/i18next.min.js",
@@ -34,29 +33,27 @@ var paths = {
   },
 };
 
-export const clean = () => deleteAsync(["static/js", "static/css"]);
+export const clean = () => deleteAsync(["static/js", "static/css", "static/manifest.json"]);
 
 export function styles() {
   return src(paths.styles.src)
     .pipe(cleanCSS())
-    .pipe(
-      rename({
-        suffix: ".min",
-      })
-    )
-    .pipe(dest(paths.styles.dest));
+    .pipe(rename({ suffix: ".min" }))
+    .pipe(rev())
+    .pipe(dest(paths.styles.dest))
+    .pipe(rev.manifest("css-manifest.json"))
+    .pipe(dest("static/"));
 }
 
 export function scripts() {
   return src(paths.scripts.src, { sourcemaps: true })
     .pipe(babel())
     .pipe(uglify())
-    .pipe(
-      rename({
-        suffix: ".min",
-      })
-    )
-    .pipe(dest(paths.scripts.dest));
+    .pipe(rename({ suffix: ".min" }))
+    .pipe(rev())
+    .pipe(dest(paths.scripts.dest))
+    .pipe(rev.manifest("scripts-manifest.json"))
+    .pipe(dest("static/"));
 }
 
 export function dist() {
@@ -64,7 +61,48 @@ export function dist() {
     .pipe(babel())
     .pipe(uglify())
     .pipe(concat("dist.min.js"))
-    .pipe(dest(paths.dist.dest));
+    .pipe(rev())
+    .pipe(dest(paths.dist.dest))
+    .pipe(rev.manifest("dist-manifest.json"))
+    .pipe(dest("static/"));
+}
+
+// Merge all manifests into one with proper path prefixes
+export function mergeManifests(cb) {
+  const manifest = {};
+
+  // CSS manifest
+  const cssManifestPath = "static/css-manifest.json";
+  if (existsSync(cssManifestPath)) {
+    const cssManifest = JSON.parse(readFileSync(cssManifestPath, "utf8"));
+    for (const [key, value] of Object.entries(cssManifest)) {
+      manifest["/static/css/" + key] = "/static/css/" + value;
+    }
+    deleteAsync([cssManifestPath]);
+  }
+
+  // Scripts manifest (page-specific JS)
+  const scriptsManifestPath = "static/scripts-manifest.json";
+  if (existsSync(scriptsManifestPath)) {
+    const scriptsManifest = JSON.parse(readFileSync(scriptsManifestPath, "utf8"));
+    for (const [key, value] of Object.entries(scriptsManifest)) {
+      manifest["/static/js/pages/" + key] = "/static/js/pages/" + value;
+    }
+    deleteAsync([scriptsManifestPath]);
+  }
+
+  // Dist manifest (main bundle)
+  const distManifestPath = "static/dist-manifest.json";
+  if (existsSync(distManifestPath)) {
+    const distManifest = JSON.parse(readFileSync(distManifestPath, "utf8"));
+    for (const [key, value] of Object.entries(distManifest)) {
+      manifest["/static/js/" + key] = "/static/js/" + value;
+    }
+    deleteAsync([distManifestPath]);
+  }
+
+  writeFileSync("static/manifest.json", JSON.stringify(manifest, null, 2));
+  cb();
 }
 
 function watchFiles() {
@@ -74,6 +112,6 @@ function watchFiles() {
 }
 export { watchFiles as watch };
 
-const build = gulp.series(clean, gulp.parallel(styles, scripts, dist));
+const build = series(clean, parallel(styles, scripts, dist), mergeManifests);
 
 export default build;

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,7 @@
         "gulp-clean-css": "^4.3.0",
         "gulp-concat": "^2.6.1",
         "gulp-rename": "^2.0.0",
+        "gulp-rev": "^11.0.0",
         "gulp-uglify": "^3.0.2"
       }
     },
@@ -2327,6 +2328,18 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/easy-transform-stream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/easy-transform-stream/-/easy-transform-stream-1.0.1.tgz",
+      "integrity": "sha512-ktkaa6XR7COAR3oj02CF3IOgz2m1hCaY3SfzvKT4Svt2MhHw9XCt+ncJNWfe2TGz31iqzNGZ8spdKQflj+Rlog==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/editorconfig": {
       "version": "1.0.4",
@@ -5958,6 +5971,35 @@
         "minimatch": "^3.0.3"
       }
     },
+    "node_modules/gulp-plugin-extras": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/gulp-plugin-extras/-/gulp-plugin-extras-0.3.0.tgz",
+      "integrity": "sha512-I/kOBSpo61QsGQZcqozZYEnDseKvpudUafVVWDLYgBFAUJ37kW5R8Sjw9cMYzpGyPUfEYOeoY4p+dkfLqgyJUQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/vinyl": "^2.0.9",
+        "chalk": "^5.3.0",
+        "easy-transform-stream": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gulp-plugin-extras/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/gulp-plumber": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/gulp-plumber/-/gulp-plumber-1.2.1.tgz",
@@ -6158,6 +6200,35 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/gulp-rev": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/gulp-rev/-/gulp-rev-11.0.0.tgz",
+      "integrity": "sha512-KJSyw0qMQBL0xB3YhYrdinelbnWnYHDxj3jqVL2Xvn8bUA1lh7py5/2Z6fUgIWiX+F1XyKYVxI8yy9asIAvZJA==",
+      "dev": true,
+      "dependencies": {
+        "gulp-plugin-extras": "^0.3.0",
+        "modify-filename": "^2.0.0",
+        "rev-hash": "^4.1.0",
+        "rev-path": "^3.0.0",
+        "sort-keys": "^5.0.0",
+        "vinyl": "^3.0.0",
+        "vinyl-file": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "peerDependencies": {
+        "gulp": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "gulp": {
+          "optional": true
+        }
       }
     },
     "node_modules/gulp-rtlcss": {
@@ -6927,6 +6998,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
       "dev": true,
       "engines": {
         "node": ">=12"
@@ -7895,6 +7978,18 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/modify-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/modify-filename/-/modify-filename-2.0.0.tgz",
+      "integrity": "sha512-VX9/MdgUN9StpSLImJ0+AyV2dxJJtyojIwRHF/Ja942tW7FTzxXI186jDSTk4k5wj2+59a4bRzFnJUgMSi+ygg==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ms": {
@@ -9040,6 +9135,33 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rev-hash": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rev-hash/-/rev-hash-4.1.0.tgz",
+      "integrity": "sha512-e0EGnaveLY2IYpYwHNdh43WZ2M84KgW3Z/T4F6+Z/BlZI/T1ZbxTWj36xgYgUPOieGXYo2q225jTeUXn+LWYjw==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rev-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rev-path/-/rev-path-3.0.0.tgz",
+      "integrity": "sha512-2fUuv6IC7Z+Vj+DXEunJYJDZuwSsaJJHeLar3n2PGvHSH7j5+Xpd/Xh7PenekH4WQhxFuHtsGwd1dCh/HvT6Gw==",
+      "dev": true,
+      "dependencies": {
+        "modify-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/rework": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
@@ -9470,6 +9592,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/sort-keys": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-5.1.0.tgz",
+      "integrity": "sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==",
+      "dev": true,
+      "dependencies": {
+        "is-plain-obj": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/source-map": {
       "version": "0.5.7",
@@ -10318,6 +10455,67 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/vinyl-file": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/vinyl-file/-/vinyl-file-5.0.0.tgz",
+      "integrity": "sha512-MvkPF/yA1EX7c6p+juVIvp9+Lxp70YUfNKzEWeHMKpUNVSnTZh2coaOqLxI0pmOe2V9nB+OkgFaMDkodaJUyGw==",
+      "dev": true,
+      "dependencies": {
+        "@types/vinyl": "^2.0.7",
+        "strip-bom-buf": "^3.0.1",
+        "strip-bom-stream": "^5.0.0",
+        "vinyl": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vinyl-file/node_modules/first-chunk-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/first-chunk-stream/-/first-chunk-stream-5.0.0.tgz",
+      "integrity": "sha512-WdHo4ejd2cG2Dl+sLkW79SctU7mUQDfr4s1i26ffOZRs5mgv+BRttIM9gwcq0rDbemo0KlpVPaa3LBVLqPXzcQ==",
+      "dev": true,
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vinyl-file/node_modules/strip-bom-buf": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-bom-buf/-/strip-bom-buf-3.0.1.tgz",
+      "integrity": "sha512-iJaWw2WroigLHzQysdc5WWeUc99p7ea7AEgB6JkY8CMyiO1yTVAA1gIlJJgORElUIR+lcZJkNl1OGChMhvc2Cw==",
+      "dev": true,
+      "dependencies": {
+        "is-utf8": "^0.2.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/vinyl-file/node_modules/strip-bom-stream": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-stream/-/strip-bom-stream-5.0.0.tgz",
+      "integrity": "sha512-Yo472mU+3smhzqeKlIxClre4s4pwtYZEvDNQvY/sJpnChdaxmKuwU28UVx/v1ORKNMxkmj1GBuvxJQyBk6wYMQ==",
+      "dev": true,
+      "dependencies": {
+        "first-chunk-stream": "^5.0.0",
+        "strip-bom-buf": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/vinyl-fs": {

--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "gulp-clean-css": "^4.3.0",
     "gulp-concat": "^2.6.1",
     "gulp-rename": "^2.0.0",
+    "gulp-rev": "^11.0.0",
     "gulp-uglify": "^3.0.2"
   },
   "dependencies": {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -13,11 +13,11 @@
       <link
         rel="stylesheet"
         type="text/css"
-        href="/static/css/semantic.min.css" />
+        href="{{ asset "/static/css/semantic.min.css" }}" />
       <link
         rel="stylesheet"
         type="text/css"
-        href="/static/css/akatsuki.min.css" />
+        href="{{ asset "/static/css/akatsuki.min.css" }}" />
       <link
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" />
@@ -49,7 +49,7 @@
       <script
         src="https://cdn.jsdelivr.net/npm/twemoji@14.0.2/dist/twemoji.min.js"
         crossorigin="anonymous"></script>
-      <script src="/static/js/dist.min.js"></script>
+      <script src="{{ asset "/static/js/dist.min.js" }}"></script>
 
       <style>
         body {

--- a/web/templates/beatmap.html
+++ b/web/templates/beatmap.html
@@ -1,5 +1,5 @@
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/leaderboard.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/leaderboard.min.css" }}" />
   <div class="ui container">
     {{ $ := . }}
     {{ if ne .Beatmapset.ID 0 }}

--- a/web/templates/clanboard.html
+++ b/web/templates/clanboard.html
@@ -8,7 +8,7 @@ BannerType=1
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
   <div class="ui container akat-box">
-    <link rel="stylesheet" href="/static/css/pages/clanboard.min.css" />
+    <link rel="stylesheet" href="{{ asset "/static/css/pages/clanboard.min.css" }}" />
 
     {{ $favMode := 0.0 }}
     {{ if .Context.User.ID }}

--- a/web/templates/clansample.html
+++ b/web/templates/clansample.html
@@ -4,7 +4,7 @@ Include=clan_member.html
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/clanpage.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/clanpage.min.css" }}" />
   {{ if .ClanID }}
     {{ $global := . }}
 

--- a/web/templates/followers.html
+++ b/web/templates/followers.html
@@ -8,7 +8,7 @@ BannerType=1
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/clanpage.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/clanpage.min.css" }}" />
   <div class="ui container">
     <div class="ui segments">
       <div class="ui segment">

--- a/web/templates/friends.html
+++ b/web/templates/friends.html
@@ -8,7 +8,7 @@ BannerType=1
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/clanpage.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/clanpage.min.css" }}" />
   <div class="ui container">
     <div class="ui segments">
       <div class="ui segment">

--- a/web/templates/homepage.html
+++ b/web/templates/homepage.html
@@ -19,7 +19,7 @@
     <meta name="twitter:card" content="" />
   </head>
 
-  <link rel="stylesheet" href="/static/css/pages/home.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/home.min.css" }}" />
 
   <div class="masthead segment bg14">
     <div class="ui container">

--- a/web/templates/leaderboard.html
+++ b/web/templates/leaderboard.html
@@ -7,7 +7,7 @@ BannerType=1
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/leaderboard.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/leaderboard.min.css" }}" />
 
   <div class="ui container akat-box">
     {{ $favMode := 0.0 }}

--- a/web/templates/multiplayer.html
+++ b/web/templates/multiplayer.html
@@ -4,7 +4,7 @@
       <link
         rel="stylesheet"
         type="text/css"
-        href="/static/css/pages/multiplayer.min.css" />
+        href="{{ asset "/static/css/pages/multiplayer.min.css" }}" />
     </head>
     <script>
       const matchID = "{{ .MatchID }}";

--- a/web/templates/profile.html
+++ b/web/templates/profile.html
@@ -49,8 +49,8 @@
         window.graphType = "rank";
       </script>
 
-      <link rel="stylesheet" href="/static/css/pages/profile.min.css" />
-      <link rel="stylesheet" href="/static/css/pages/bbcode.min.css" />
+      <link rel="stylesheet" href="{{ asset "/static/css/pages/profile.min.css" }}" />
+      <link rel="stylesheet" href="{{ asset "/static/css/pages/bbcode.min.css" }}" />
 
       <div class="ui container margin">
         <div class="profile-info-container">

--- a/web/templates/settings/userpage.html
+++ b/web/templates/settings/userpage.html
@@ -11,7 +11,7 @@ MinPrivileges=2
 {{ define "tpl" }}
   {{ $ := . }}
   {{ $can_userpage := qb "SELECT 1 FROM users WHERE id = ? AND userpage_allowed LIMIT 1" .Context.User.ID }}
-  <link rel="stylesheet" href="/static/css/pages/bbcode.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/bbcode.min.css" }}" />
   <div class="ui container">
     <div class="ui stackable grid">
       {{ template "settingsSidebar" . }}

--- a/web/templates/team.html
+++ b/web/templates/team.html
@@ -8,7 +8,7 @@ BannerType=1
 */}}
 {{/* prettier-ignore-end */}}
 {{ define "tpl" }}
-  <link rel="stylesheet" href="/static/css/pages/clanpage.min.css" />
+  <link rel="stylesheet" href="{{ asset "/static/css/pages/clanpage.min.css" }}" />
   <div class="ui container">
     <div class="ui segments">
       <div class="ui center aligned segment">


### PR DESCRIPTION
## Summary
- Add content hashing to static assets (CSS, JS) via gulp-rev
- Assets now have hashes in filenames (e.g., `dist-6be422ed18.min.js`)
- Templates use new `{{ asset "/static/..." }}` function to lookup hashed paths
- Enables immutable caching in nginx (companion PRs)

## Changes

### gulpfile.js
- Add `gulp-rev` dependency for content hashing
- Generate `manifest.json` mapping original → hashed paths

### funcmap.go
- Add `asset` template function that reads manifest and returns hashed path
- Gracefully falls back to original path if manifest missing

### Templates
- Update all CSS/JS references to use `{{ asset "..." }}`

## Example manifest.json
```json
{
  "/static/js/dist.min.js": "/static/js/dist-6be422ed18.min.js",
  "/static/css/semantic.min.css": "/static/css/semantic-578b631c76.min.css"
}
```

## Test plan
- [ ] Run `cd web && npx gulp` and verify manifest.json is generated
- [ ] Run hanayo locally and verify assets load with hashed filenames
- [ ] Check browser dev tools for correct Cache-Control headers (after nginx PRs)

## Related PRs
- nginx-conf public-rev-proxy: https://github.com/osuAkatsuki/nginx-conf/pull/37
- nginx-conf k8s-rev-proxy: https://github.com/osuAkatsuki/nginx-conf/pull/38

🤖 Generated with [Claude Code](https://claude.com/claude-code)