### PR TITLE
Fix font loading FOUT

### DIFF
--- a/web/src/css/semantic.css
+++ b/web/src/css/semantic.css
@@ -9,7 +9,6 @@
  *
 */
 
-@import url('https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600&display=swap');
 html {
   --font: "Rubik", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"
 }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -10,6 +10,11 @@
       <title>{{ if .TitleBar }}{{ .T .TitleBar }} - {{ end }}Akatsuki</title>
       {{/* prettier-ignore-end */}}
 
+      <!-- Fonts -->
+      <link rel="preconnect" href="https://fonts.googleapis.com">
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;500;600&display=block">
+
       <link
         rel="stylesheet"
         type="text/css"


### PR DESCRIPTION
## Summary

Fixes the flash of unstyled text (FOUT) where the fallback font briefly shows before Rubik loads.

### Changes

1. **Move font loading from CSS to HTML** - Removes `@import` from semantic.css and adds `<link>` in base.html
2. **Add preconnect hints** - Starts DNS/TLS handshake early for Google Fonts
3. **Use `display=block`** - Hides text briefly until font is ready (instead of `swap` which shows fallback then swaps)

### Why this is better

**Before (CSS @import + swap):**
```
HTML → semantic.css → Google Fonts CSS → Font files
         ↓
    Text visible with fallback font, then swaps (FOUT)
```

**After (HTML link + preconnect + block):**
```
HTML → [semantic.css + Google Fonts CSS in parallel]
  ↓
Text hidden briefly, then appears with correct font (no flash)
```

The preconnect hints make the font load fast enough that the block period is barely noticeable.

## Test plan
- [ ] Load page and verify no font swap flash
- [ ] Check network tab - Google Fonts should load in parallel with CSS
- [ ] Verify Rubik font displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)