### PR TITLE
Fix always-visible scrollbar with flexbox layout

### DIFF
--- a/web/src/css/akatsuki.css
+++ b/web/src/css/akatsuki.css
@@ -1,3 +1,9 @@
+body {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
 @media (max-width: 576px) {
   .row {
     margin-right: 0 !important;
@@ -252,10 +258,11 @@ a.inherit:hover {
 }
 
 .main.wrapper {
-  min-height: calc(100vh - 45.99px);
+  flex: 1;
 }
 
 .footer {
+  flex-shrink: 0;
   padding: 15px 20px;
   background: hsl(var(--base), 0%, 2%);
 }


### PR DESCRIPTION
## Summary
- Replaces hardcoded `min-height: calc(100vh - 45.99px)` with flexbox layout
- The magic number didn't match the actual footer height, causing pages to always exceed viewport height and show a scrollbar

## Changes
- Add `display: flex; flex-direction: column; min-height: 100vh` to body
- Change `.main.wrapper` to use `flex: 1` instead of calc-based min-height
- Add `flex-shrink: 0` to footer to prevent compression

🤖 Generated with [Claude Code](https://claude.com/claude-code)