### PR TITLE
Add defer to dist.min.js to unblock rendering

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -53,7 +53,7 @@
       <script
         src="https://cdn.jsdelivr.net/npm/twemoji@14.0.2/dist/twemoji.min.js"
         crossorigin="anonymous"></script>
-      <script src="{{ asset "/static/js/dist.min.js" }}"></script>
+      <script src="{{ asset "/static/js/dist.min.js" }}" defer></script>
 
       <style>
         body {
@@ -185,12 +185,14 @@
       </center>
 
       <script>
-        $(".language-select").on("click", function (event) {
-          event.stopPropagation();
-          event.stopImmediatePropagation();
-          var lang = $(this).data("lang");
-          document.cookie = "language=" + lang + ";path=/;max-age=31536000";
-          window.location.reload();
+        document.addEventListener("DOMContentLoaded", function () {
+          $(".language-select").on("click", function (event) {
+            event.stopPropagation();
+            event.stopImmediatePropagation();
+            var lang = $(this).data("lang");
+            document.cookie = "language=" + lang + ";path=/;max-age=31536000";
+            window.location.reload();
+          });
         });
       </script>
 


### PR DESCRIPTION
## Summary
- Adds `defer` attribute to dist.min.js so HTML parsing isn't blocked
- Wraps inline language selector script in DOMContentLoaded (since it uses jQuery from the deferred bundle)

## Impact
Improves First Contentful Paint by allowing the browser to continue parsing HTML while downloading JavaScript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)