### PR TITLE
Fix page-specific scripts not using content hashes

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -196,7 +196,7 @@
 
       {{ if .Scripts }}
         {{ range .Scripts }}
-          <script src="{{ . }}"></script>
+          <script src="{{ asset . }}"></script>
         {{ end }}
       {{ end }}
     </body>


### PR DESCRIPTION
## Summary
Page-specific scripts (profile.min.js, clan.min.js, etc.) were returning 404 because the template rendered them without going through the `asset` function to resolve content-hashed filenames.

## Fix
Use `{{ asset . }}` instead of `{{ . }}` when rendering script paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)