### PR TITLE
Remove pace.js loading progress bar

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -27,11 +27,6 @@
         rel="stylesheet"
         href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.1.1/css/all.min.css" />
 
-      <script src="https://cdn.jsdelivr.net/npm/pace-js@latest/pace.min.js" async></script>
-      <link
-        rel="stylesheet"
-        href="https://cdn.jsdelivr.net/npm/pace-js@latest/pace-theme-default.min.css" />
-
       <!-- Amplitude Browser SDK 2.0 -->
       <script type="text/javascript">
         // prettier-ignore


### PR DESCRIPTION
## Summary
- Remove pace.js library (script + CSS)
- 2013-era library that shows fake progress bar during page loads
- Modern browsers provide native loading indicators, making this redundant
- Eliminates ~4KB JS + CSS and XHR hook overhead

## Test plan
- [x] Verify page loads without JavaScript errors
- [x] Verify no pace.js references in HTML output

🤖 Generated with [Claude Code](https://claude.com/claude-code)