### PR TITLE
Add defer to page-specific scripts

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -190,7 +190,7 @@
 
       {{ if .Scripts }}
         {{ range .Scripts }}
-          <script src="{{ asset . }}"></script>
+          <script src="{{ asset . }}" defer></script>
         {{ end }}
       {{ end }}
     </body>


### PR DESCRIPTION
## Summary
Fixes `$ is not defined` error on profile page (and likely other pages with scripts).

Page scripts like profile.min.js were executing before dist.min.js (which contains jQuery) because:
- dist.min.js has `defer` → runs after HTML parsing
- Page scripts had no `defer` → ran immediately when parsed

Adding `defer` to page scripts ensures they execute in document order, after dist.min.js.

## Test plan
- [ ] Verify profile page loads without JS errors
- [ ] Verify beatmap page loads without JS errors
- [ ] Verify clan page loads without JS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)