### PR TITLE
Fix beatmap preview audio button not working

### DIFF
--- a/web/templates/beatmap.html
+++ b/web/templates/beatmap.html
@@ -109,7 +109,7 @@
                   {{ end }}
                   <a
                     class="ui purple labeled icon button"
-                    onclick="playPreview()">
+                    id="preview-btn">
                     <i class="fa-solid fa-play icon" id="preview-icon"></i>
                     <span id="preview-text">{{ $.T "Preview Audio" }}</span>
                   </a>
@@ -138,35 +138,35 @@
         var currentModeChanged = false;
         var currentCmodeChanged = false;
 
-        var previewAudio = document.querySelector("#beatmap-preview")
-        var previewText = document.querySelector("#preview-text")
-        var previewIcon = $("#preview-icon")
-        var previewPlaying = false
-        previewAudio.volume = 0.2
+        document.addEventListener("DOMContentLoaded", function () {
+          var $previewAudio = $("#beatmap-preview");
+          var $previewText = $("#preview-text");
+          var $previewIcon = $("#preview-icon");
+          var previewPlaying = false;
+          $previewAudio.prop("volume", 0.2);
 
-        previewAudio.onplaying = () => {
-          previewPlaying = true
-          previewText.innerHTML = '{{ .T "Pause Audio" }}';
-          previewIcon.removeClass("fa-play").addClass("fa-pause");
-        }
+          $previewAudio.on("playing", function () {
+            previewPlaying = true;
+            $previewText.text('{{ .T "Pause Audio" }}');
+            $previewIcon.removeClass("fa-play").addClass("fa-pause");
+          });
 
-        previewAudio.onpause = () => {
-          previewPlaying = false
-          previewText.innerHTML = '{{ .T "Preview Audio" }}';
-          previewIcon.removeClass("fa-pause").addClass("fa-play");
-        }
+          $previewAudio.on("pause", function () {
+            previewPlaying = false;
+            $previewText.text('{{ .T "Preview Audio" }}');
+            $previewIcon.removeClass("fa-pause").addClass("fa-play");
+          });
 
-        previewAudio.onended = () => {
-          previewPlaying = false
-          previewText.innerHTML = '{{ .T "Preview Audio" }}';
-          previewIcon.removeClass("fa-pause").addClass("fa-play");
+          $previewAudio.on("ended", function () {
+            previewPlaying = false;
+            $previewText.text('{{ .T "Preview Audio" }}');
+            $previewIcon.removeClass("fa-pause").addClass("fa-play");
+          });
 
-        }
-
-        // Le curse.
-        const playPreview = () => {
-          previewPlaying ? previewAudio.pause() : previewAudio.play()
-        }
+          $("#preview-btn").on("click", function () {
+            previewPlaying ? $previewAudio[0].pause() : $previewAudio[0].play();
+          });
+        });
       </script>
 
       <div class="akat-box ui segment">

--- a/web/templates/clansample.html
+++ b/web/templates/clansample.html
@@ -193,16 +193,18 @@ Include=clan_member.html
                         </a>
                       </div>
                       <script>
-                        $("#inv-btn>.item").on("click", function (e) {
-                          e.preventDefault();
-                          if (!currentUserID) return;
+                        document.addEventListener("DOMContentLoaded", function () {
+                          $("#inv-btn>.item").on("click", function (e) {
+                            e.preventDefault();
+                            if (!currentUserID) return;
 
-                          var inv = prompt("Enter the Clan's Invite");
+                            var inv = prompt("Enter the Clan's Invite");
 
-                          if (inv == null || inv == "") return;
+                            if (inv == null || inv == "") return;
 
-                          var btn = $(this);
-                          joinClan({ invite: inv }, btn);
+                            var btn = $(this);
+                            joinClan({ invite: inv }, btn);
+                          });
                         });
                       </script>
                     {{ end }}

--- a/web/templates/navbar.html
+++ b/web/templates/navbar.html
@@ -235,12 +235,11 @@
       </div>
     </div>
     <script>
-      $(document).ready(() => {
+      document.addEventListener("DOMContentLoaded", () => {
         // Dropdowns for mobile view.
         $("[data-menu]").on("click", function () {
           dropdownType = $(this).data("menu");
           isInvoked = $(this).data("invoked") == "true";
-          console.log(dropdownType, isInvoked);
 
           dropdown = $(`[data-dropdown-menu="${dropdownType}"]`);
           dropdownIcon = $(`[data-dropdown-icon="${dropdownType}"]`);


### PR DESCRIPTION
## Summary
Fixed inline scripts that broke after deferring `dist.min.js` - they were using jQuery (`$`) before it loaded.

## Changes
All fixed by wrapping in `DOMContentLoaded` (fires after deferred scripts execute):

| File | Changes |
|------|---------|
| beatmap.html | Wrap in DOMContentLoaded, replace `onclick` with event listener |
| navbar.html | Replace `$(document).ready()` with `DOMContentLoaded` |
| clansample.html | Wrap invite button handler in `DOMContentLoaded` |

## Why this works
`DOMContentLoaded` fires **after** deferred scripts execute, so jQuery is guaranteed to be available inside the callback.

## Test plan
- [ ] Beatmap page: Click "Preview Audio" button - should play/pause audio
- [ ] Navbar (mobile): Click dropdown menus - should expand/collapse
- [ ] Clan page: Click "Ask for Invite" button - should prompt for invite code

🤖 Generated with [Claude Code](https://claude.ai/code)