### PR TITLE
Move global inline scripts to akatsuki_src.js

### DIFF
--- a/web/src/js/akatsuki_src.js
+++ b/web/src/js/akatsuki_src.js
@@ -693,10 +693,35 @@ $(document).ready(function () {
   $.timeago.settings.allowFuture = true;
   $("time.timeago").timeago();
 
-  $("#language-select").on("click", function () {
+  // Language selector
+  $(".language-select").on("click", function (event) {
+    event.stopPropagation();
+    event.stopImmediatePropagation();
     var lang = $(this).data("lang");
     document.cookie = "language=" + lang + ";path=/;max-age=31536000";
     window.location.reload();
+  });
+
+  // Mobile navbar dropdowns
+  $("[data-menu]").on("click", function () {
+    var dropdownType = $(this).data("menu");
+    var isInvoked = $(this).data("invoked") == "true";
+    var $dropdown = $('[data-dropdown-menu="' + dropdownType + '"]');
+    var $dropdownIcon = $('[data-dropdown-icon="' + dropdownType + '"]');
+
+    if (!isInvoked) {
+      $(this).data("invoked", "true");
+      $dropdown.slideDown(300, function () {
+        $dropdown.css("display", "");
+        $dropdownIcon.removeClass("fa-caret-down").addClass("fa-caret-up");
+      });
+    } else {
+      $(this).data("invoked", "false");
+      $dropdown.slideUp(300, function () {
+        $dropdown.css("display", "none");
+        $dropdownIcon.removeClass("fa-caret-up").addClass("fa-caret-down");
+      });
+    }
   });
 
   // hook submit button to handle validation of username input

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -176,18 +176,6 @@
         </div>
       </center>
 
-      <script>
-        document.addEventListener("DOMContentLoaded", function () {
-          $(".language-select").on("click", function (event) {
-            event.stopPropagation();
-            event.stopImmediatePropagation();
-            var lang = $(this).data("lang");
-            document.cookie = "language=" + lang + ";path=/;max-age=31536000";
-            window.location.reload();
-          });
-        });
-      </script>
-
       {{ if .Scripts }}
         {{ range .Scripts }}
           <script src="{{ asset . }}" defer></script>

--- a/web/templates/navbar.html
+++ b/web/templates/navbar.html
@@ -234,31 +234,5 @@
         {{ end }}
       </div>
     </div>
-    <script>
-      $(document).ready(() => {
-        // Dropdowns for mobile view.
-        $("[data-menu]").on("click", function () {
-          dropdownType = $(this).data("menu");
-          isInvoked = $(this).data("invoked") == "true";
-          console.log(dropdownType, isInvoked);
-
-          dropdown = $(`[data-dropdown-menu="${dropdownType}"]`);
-          dropdownIcon = $(`[data-dropdown-icon="${dropdownType}"]`);
-          if (!isInvoked) {
-            $(this).data("invoked", "true");
-            dropdown.slideDown(300, () => {
-              dropdown.css("display", "");
-              dropdownIcon.removeClass("fa-caret-down").addClass("fa-caret-up");
-            });
-          } else {
-            $(this).data("invoked", "false");
-            dropdown.slideUp(300, () => {
-              dropdown.css("display", "none");
-              dropdownIcon.removeClass("fa-caret-up").addClass("fa-caret-down");
-            });
-          }
-        });
-      });
-    </script>
   </div>
 {{ end }}


### PR DESCRIPTION
## Summary
Centralize global behavior scripts instead of inlining them in templates. This improves cacheability, enables minification, and avoids jQuery timing issues.

## Changes
**Moved to akatsuki_src.js:**
- Language selector click handler (also fixed selector from `#language-select` to `.language-select`)
- Mobile navbar dropdown toggle

**Removed inline scripts from:**
- `base.html` - language selector
- `navbar.html` - mobile dropdown

## Benefits
- Scripts are minified and cached with dist.min.js
- No jQuery timing issues (already inside `$(document).ready()`)
- Templates only contain data initialization, not behavior
- Easier to maintain and test

## Test plan
- [ ] Click language selector in footer - should change language
- [ ] On mobile: click navbar dropdown menus - should expand/collapse

🤖 Generated with [Claude Code](https://claude.ai/code)