### PR TITLE
Move clan invite button handler to clan.js

### DIFF
--- a/web/src/js/pages/clan.js
+++ b/web/src/js/pages/clan.js
@@ -103,6 +103,18 @@ $(document).ready(function () {
       !0
     );
   });
+
+  // Invite-only clan join button
+  $("#inv-btn>.item").on("click", function (e) {
+    e.preventDefault();
+    if (!currentUserID) return;
+
+    var inv = prompt("Enter the Clan's Invite");
+    if (inv == null || inv == "") return;
+
+    var btn = $(this);
+    joinClan({ invite: inv }, btn);
+  });
 });
 
 function joinClan(obj, btn) {

--- a/web/templates/clansample.html
+++ b/web/templates/clansample.html
@@ -192,19 +192,6 @@ Include=clan_member.html
                           Ask for Invite
                         </a>
                       </div>
-                      <script>
-                        $("#inv-btn>.item").on("click", function (e) {
-                          e.preventDefault();
-                          if (!currentUserID) return;
-
-                          var inv = prompt("Enter the Clan's Invite");
-
-                          if (inv == null || inv == "") return;
-
-                          var btn = $(this);
-                          joinClan({ invite: inv }, btn);
-                        });
-                      </script>
                     {{ end }}
                   {{ end }}
                 {{ else }}


### PR DESCRIPTION
## Summary
Centralize clan page JavaScript instead of mixing inline scripts with behavior.

## Changes
**clan.js:**
- Added invite-only clan join button click handler
- Uses existing `joinClan()` function

**clansample.html:**
- Removed inline script block

## Benefits
- Script is minified and cached
- No jQuery timing issues
- Consistent with other button handlers (join-btn, leave-btn) already in clan.js
- Clean separation: templates have markup, JS files have behavior

## Test plan
- [ ] Visit a clan page that requires an invite (status = 2)
- [ ] Click "Ask for Invite" button - should prompt for invite code
- [ ] Enter valid invite - should join clan
- [ ] Enter invalid/empty invite - should show error or do nothing

🤖 Generated with [Claude Code](https://claude.ai/code)