### PR TITLE
UI Refresh Phase 3: Profile Page

### DIFF
--- a/web/src/css/pages/profile.css
+++ b/web/src/css/pages/profile.css
@@ -145,18 +145,18 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-direction: column;
-  font-size: 20px;
-  padding: 11px;
-  background: #292929e3;
-  border-radius: 5px;
+  flex-direction: row;
+  font-size: 18px;
+  padding: 12px 16px;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border-radius: 8px;
   margin-bottom: 4px;
-  float: right;
-  margin-top: 40%;
 }
 
 .ranks-column {
-  width: 23% !important;
+  display: none;
 }
 
 .profile-rank {
@@ -170,25 +170,13 @@
   width: 20px;
 }
 
-@media screen and (max-width: 1199px) {
-  .ranks-column {
-    width: 20% !important;
-  }
-  .profile-rank-container {
-    margin-top: 60%;
-  }
+/* Rank container embedded in profile info on all screen sizes */
+.profile-info .profile-rank-container {
+  margin-top: 12px;
+  justify-content: flex-start;
 }
 
-@media screen and (max-width: 991px) {
-  .ranks-column {
-    width: 15% !important;
-  }
-  .profile-rank-container {
-    margin-top: 120%;
-  }
-}
-
-@media screen and (max-width: 499px) {
+@media screen and (max-width: 576px) {
   .profile-badges:has(.badge) {
     display: grid;
     gap: 4px;
@@ -287,7 +275,7 @@
   font-size: 0.6em !important;
 }
 
-@media only screen and (min-width: 767px) {
+@media only screen and (min-width: 769px) {
   .profile-avatar {
     height: 140px;
     width: 140px;
@@ -333,7 +321,7 @@
   margin: 0;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .flex {
     justify-content: center;
   }
@@ -350,8 +338,8 @@
   .profile-rank-container {
     position: static;
     font-size: 14px;
-    gap: 4px;
-    padding: 6px;
+    gap: 8px;
+    padding: 8px 12px;
   }
 }
 
@@ -638,7 +626,7 @@
   transform: scale(0.95);
 }
 
-@media screen and (max-width: 600px) {
+@media screen and (max-width: 576px) {
   .subtitle {
     width: 200px;
   }
@@ -653,12 +641,25 @@
   pointer-events: none;
 }
 
+/* Profile layout grid - use modern CSS Grid */
+.profile-main-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+@media (min-width: 993px) {
+  .profile-main-grid {
+    grid-template-columns: 280px 1fr;
+  }
+}
+
 .vark-info-grid {
-  width: 29.25% !important;
+  width: 100% !important;
 }
 
 .vark-list-grid {
-  width: 70.75% !important;
+  width: 100% !important;
 }
 
 .badge {
@@ -677,16 +678,7 @@
   margin: 0px !important;
 }
 
-@media only screen and (max-width: 992px) {
-  .vark-info-grid {
-    width: 100% !important;
-  }
-  .vark-list-grid {
-    width: 100% !important;
-  }
-}
-
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 768px) {
   .bar-selection {
     display: block;
   }
@@ -715,38 +707,62 @@
   margin-bottom: 1.5em !important;
 }
 
-@media only screen and (max-width: 700px) {
+@media only screen and (max-width: 768px) {
   .map-single {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    border-radius: 8px;
+    overflow: hidden;
   }
 
   .map-data {
-    display: block;
+    display: flex;
+    flex-direction: column;
   }
 
   .map-image {
     width: 100%;
+    height: 100px;
     background-size: cover;
+    background-position: center;
+  }
+
+  .map-content1 {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
   .map-title-block {
-    padding: 1.2rem 0px 0px 0px;
+    padding: 12px;
+    margin-left: 0;
+    width: 100%;
   }
 
   .map-content2 {
-    padding: 0px 0px 1.2rem 0px;
+    padding: 0 12px 12px 12px;
+    align-items: flex-start;
   }
 
   .map-grade {
-    font-size: 3rem;
+    font-size: 2.5rem;
   }
 
   .map-padding {
-    padding-bottom: 1.2rem;
+    padding-bottom: 12px;
+  }
+
+  .score-details_right-block {
+    flex-direction: row;
+    justify-content: space-between;
+    width: 100%;
+    padding: 8px 12px;
+    margin-left: 0;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0;
   }
 }
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 576px) {
   .avatar-container {
     margin-bottom: -1.2em !important;
   }


### PR DESCRIPTION
## Summary
Improves profile page responsiveness and modernizes the layout.

**Note:** This PR is stacked on #217 (Phase 2) and should be merged after it.

## Changes

### Layout Improvements
- Add CSS Grid for main profile layout
- Replace fixed percentage widths (29.25%, 70.75%) with responsive grid
- Grid switches from single column to two-column at 992px+

### Rank Container Fixes
- Remove brittle `margin-top: 40%/60%/120%` percentage positioning
- Add `backdrop-filter: blur()` for modern glass effect
- Display ranks in a row instead of column
- Better integrated with profile info section

### Mobile Score Cards
- Better vertical stacking on mobile
- Full-width beatmap images
- Reorganized score details layout
- Improved touch targets and spacing

### Breakpoint Standardization
Updated non-standard breakpoints:
- 499px, 500px → 576px
- 600px, 700px → 768px (as appropriate)
- 767px → 768px

## Test plan
- [ ] Check profile page on mobile (< 576px)
- [ ] Check profile page on tablet (768px - 992px)
- [ ] Check profile page on desktop (> 992px)
- [ ] Verify rank container displays correctly
- [ ] Test score cards stack properly on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)