### PR TITLE
UI Refresh Phase 4: Leaderboard & Tables

### DIFF
--- a/web/src/css/pages/leaderboard.css
+++ b/web/src/css/pages/leaderboard.css
@@ -1,8 +1,17 @@
+/* Leaderboard table wrapper for horizontal scroll on mobile */
+.leaderboard-table-wrapper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: 0 -1rem;
+  padding: 0 1rem;
+}
+
 .leaderboard-table {
   white-space: nowrap;
   padding-bottom: 24px;
   transition: 0.2s ease;
   border-spacing: 0 3px !important;
+  min-width: 600px;
 }
 
 .t-heading {
@@ -23,6 +32,10 @@
   background: hsl(0, 0%, 18%);
 }
 
+.l-player td {
+  padding: 8px 12px;
+}
+
 .l-player td div a {
   display: block !important;
   position: relative;
@@ -39,17 +52,62 @@
   grid-template-columns: auto auto;
 }
 
-/* td:first-child {
-  border-top-left-radius: 4px; 
-  border-bottom-left-radius: 4px;
+/* Sticky rank column on mobile */
+.l-player td:first-child {
+  position: sticky;
+  left: 0;
+  background: inherit;
+  z-index: 1;
 }
-td:last-child {
-  border-bottom-right-radius: 4px; 
-  border-top-right-radius: 4px; 
-} */
 
-@media (max-width: 767px) {
+/* Pagination improvements */
+.simplepag {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  padding: 12px 0;
+}
+
+.simplepag .ui.pagination.menu {
+  margin: 0;
+}
+
+.simplepag .icon.item {
+  min-width: 44px;
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Mobile optimizations */
+@media (max-width: 768px) {
+  .leaderboard-table {
+    font-size: 14px;
+  }
+
+  .t-heading {
+    padding: 4px 8px !important;
+    font-size: 11px;
+  }
+
+  .l-player td {
+    padding: 6px 8px;
+  }
+
   td:nth-child(2) {
     text-align: center !important;
+  }
+}
+
+/* Very small screens - compact mode */
+@media (max-width: 576px) {
+  .leaderboard-table {
+    font-size: 13px;
+  }
+
+  .l-player td {
+    padding: 4px 6px;
   }
 }

--- a/web/templates/simplepag.html
+++ b/web/templates/simplepag.html
@@ -1,18 +1,19 @@
 {{ define "simplepag" }}
   <tr>
     <th colspan="{{ . }}">
-      <div class="simplepag">
-        <div class="ui left floated pagination menu">
-          <a class="icon item">
+      <nav class="simplepag" aria-label="Pagination">
+        <div class="ui pagination menu">
+          <a class="icon item" aria-label="Previous page" role="button">
             <i class="left chevron icon"></i>
           </a>
         </div>
-        <div class="ui right floated pagination menu">
-          <a class="icon item">
+        <span class="simplepag-info" aria-live="polite"></span>
+        <div class="ui pagination menu">
+          <a class="icon item" aria-label="Next page" role="button">
             <i class="right chevron icon"></i>
           </a>
         </div>
-      </div>
+      </nav>
     </th>
   </tr>
 {{ end }}


### PR DESCRIPTION
## Summary
Makes leaderboard tables mobile-friendly with horizontal scrolling and improves pagination.

**Note:** This PR is stacked on #218 (Phase 3) and should be merged after it.

## Changes

### Table Responsiveness
- Add `.leaderboard-table-wrapper` for horizontal scrolling on mobile
- Set `min-width: 600px` on table to maintain readability
- Sticky rank column stays visible while scrolling horizontally

### Pagination Improvements
- Use flexbox for centered layout
- Minimum touch target size (44px) for pagination buttons
- Add ARIA labels for accessibility (`aria-label`, `aria-live`)
- Change from `<div>` to `<nav>` for semantic HTML

### Mobile Optimizations
- Smaller font sizes at 768px and 576px breakpoints
- Tighter padding on mobile
- Consistent with standardized breakpoints

## Test plan
- [ ] Test horizontal scroll on mobile
- [ ] Verify sticky rank column works
- [ ] Test pagination buttons are easy to tap
- [ ] Check table is readable at different viewport sizes

🤖 Generated with [Claude Code](https://claude.ai/code)