### PR TITLE
UI Refresh Phase 5: Settings Pages

### DIFF
--- a/web/src/css/akatsuki.css
+++ b/web/src/css/akatsuki.css
@@ -1084,3 +1084,32 @@ body::-webkit-scrollbar-thumb {
 .btn-disabled:hover {
   background: hsl(var(--base),0%,15%) !important;
 }
+
+/* Settings page sidebar responsive styles */
+@media (max-width: 768px) {
+  /* Make sidebar full width on mobile */
+  .ui.stackable.grid > .four.wide.column:has(.ui.fluid.vertical.menu) {
+    width: 100% !important;
+    margin-bottom: var(--space-md);
+  }
+
+  /* Convert vertical menu to horizontal on mobile */
+  .ui.fluid.vertical.menu {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
+  }
+
+  .ui.fluid.vertical.menu .item {
+    flex: 1 1 auto;
+    text-align: center;
+    min-width: 100px;
+    padding: var(--space-sm) var(--space-md) !important;
+    border-radius: var(--radius-sm);
+  }
+
+  /* Make main content full width */
+  .ui.stackable.grid > .twelve.wide.column {
+    width: 100% !important;
+  }
+}


### PR DESCRIPTION
## Summary
Makes the settings page sidebar responsive by converting it to a horizontal layout on mobile.

**Note:** This PR is stacked on #219 (Phase 4) and should be merged after it.

## Changes

### Sidebar Responsiveness
- Sidebar becomes full width on mobile (< 768px)
- Vertical menu converts to horizontal flex layout
- Menu items wrap and fill available space evenly
- Minimum width ensures items are readable

### Touch Target Improvements
- Better padding on menu items
- Items have border radius for modern look
- Main content section also becomes full width

## Test plan
- [ ] Visit settings page on mobile
- [ ] Verify sidebar is horizontal at top
- [ ] Check menu items are easy to tap
- [ ] Test all settings sub-pages work correctly
- [ ] Verify desktop layout is unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)