### PR TITLE
Fix profile rank container and mobile layout

### DIFF
--- a/web/src/css/pages/profile.css
+++ b/web/src/css/pages/profile.css
@@ -50,6 +50,15 @@
   background-color: var(--user-bg, rgb(5, 5, 5));
 }
 
+@media (max-width: 767px) {
+  .profile-heading-image,
+  .profile-heading-solid {
+    height: auto;
+    min-height: 250px;
+    padding-bottom: 20px;
+  }
+}
+
 .profile-heading-customisation {
   position: absolute;
   backdrop-filter: blur(1px);
@@ -353,6 +362,47 @@
     font-size: 14px;
     gap: 4px;
     padding: 6px;
+  }
+
+  /* Mobile profile card layout */
+  #profile-info > .row {
+    flex-direction: column !important;
+    align-items: center !important;
+  }
+
+  .avatar-column {
+    width: 100% !important;
+    display: flex !important;
+    justify-content: center !important;
+    margin-bottom: 12px;
+  }
+
+  #profile-info .ten.wide.column {
+    width: 100% !important;
+    text-align: center;
+  }
+
+  .profile-user-info {
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .profile-smaller-section {
+    justify-content: center;
+  }
+
+  .profile-badges {
+    justify-content: center;
+  }
+
+  .bottom-column {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  .ranks-column {
+    display: none !important;
   }
 }
 

--- a/web/src/css/pages/profile.css
+++ b/web/src/css/pages/profile.css
@@ -140,6 +140,11 @@
   margin-bottom: 4px;
 }
 
+#profile-info > .row {
+  display: flex !important;
+  align-items: flex-end !important;
+}
+
 .profile-rank-container {
   width: auto;
   display: flex;
@@ -147,12 +152,13 @@
   gap: 8px;
   flex-direction: column;
   font-size: 20px;
-  padding: 11px;
+  padding: 12px 16px;
   background: var(--color-bg-elevated);
   border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
   margin-bottom: 4px;
   float: right;
-  margin-top: 40%;
+  min-width: 90px;
 }
 
 .ranks-column {
@@ -164,6 +170,7 @@
   flex-direction: row;
   align-items: center;
   gap: 8px;
+  white-space: nowrap;
 }
 
 .profile-rank-flag {
@@ -174,17 +181,11 @@
   .ranks-column {
     width: 20% !important;
   }
-  .profile-rank-container {
-    margin-top: 60%;
-  }
 }
 
 @media screen and (max-width: 991px) {
   .ranks-column {
     width: 15% !important;
-  }
-  .profile-rank-container {
-    margin-top: 120%;
   }
 }
 


### PR DESCRIPTION
## Summary
- Fix profile rank container layout with long rank numbers
- Improve mobile profile card layout with proper stacking

## Changes
- **Rank container**: Use flexbox with proper styling for rank display
- **Mobile layout**: Stack avatar, username, and title vertically
- **Mobile layout**: Center all profile card elements
- **Mobile layout**: Make header height flexible to fit content
- **Mobile layout**: Hide rank container on mobile (shown elsewhere in stats)

## Test plan
- [ ] View profile with long rank numbers - should display properly
- [ ] View profile on mobile/narrow viewport - should stack vertically and center
- [ ] Verify header expands to fit all content on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)