### PR TITLE
Use CSS variables for consistent background colors

### DIFF
--- a/web/src/css/akatsuki.css
+++ b/web/src/css/akatsuki.css
@@ -1,3 +1,63 @@
+:root {
+  /* Base hue for theming (HSL) */
+  --base: 213;
+
+  /* Background colors */
+  --color-bg-primary: hsl(var(--base), 0%, 2%);
+  --color-bg-secondary: hsl(var(--base), 0%, 10%);
+  --color-bg-elevated: hsl(var(--base), 0%, 15%);
+  --color-bg-hover: hsl(var(--base), 0%, 20%);
+
+  /* Text colors */
+  --color-text-primary: #f9f9f9;
+  --color-text-secondary: rgba(255, 255, 255, 0.8);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+
+  /* Accent colors */
+  --color-accent: hsl(var(--base), 35%, 60%);
+  --color-accent-hover: hsl(var(--base), 35%, 70%);
+
+  /* Rank colors */
+  --color-rank-ss: #f9c77d;
+  --color-rank-s: #f9c77d;
+  --color-rank-a: #8ef97d;
+  --color-rank-b: #7dccf9;
+  --color-rank-c: #d17df9;
+  --color-rank-d: #f97d84;
+  --color-rank-f: #f97d7d;
+
+  /* Spacing scale */
+  --space-xs: 4px;
+  --space-sm: 8px;
+  --space-md: 16px;
+  --space-lg: 24px;
+  --space-xl: 32px;
+
+  /* Border radius */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 15px;
+
+  /* Transitions */
+  --transition-fast: 0.15s ease;
+  --transition-normal: 0.2s ease;
+  --transition-slow: 0.3s ease;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.15);
+  --shadow-md: 0 2px 10px rgba(0, 0, 0, 0.25);
+  --shadow-lg: 0 4px 20px rgba(0, 0, 0, 0.35);
+
+  /* Layout */
+  --navbar-height: 55px;
+
+  /* Responsive breakpoints (for reference in comments) */
+  /* --breakpoint-sm: 576px - Small phones */
+  /* --breakpoint-md: 768px - Tablets */
+  /* --breakpoint-lg: 992px - Laptops */
+  /* --breakpoint-xl: 1200px - Desktops */
+}
+
 body {
   display: flex;
   flex-direction: column;
@@ -20,7 +80,7 @@ i.icon {
   font-weight: 900 !important;
 }
 
-@media only screen and (max-width: 767px) {
+@media only screen and (max-width: 768px) {
   #navbar .item {
     display: none !important;
   }
@@ -28,7 +88,7 @@ i.icon {
     display: block !important;
   }
   #navbar {
-    height: 55px;
+    height: var(--navbar-height);
   }
   .firetrucking-right-menu {
     display: flex;
@@ -42,7 +102,7 @@ i.icon {
 a.navbar-icon {
   font-size: 16px;
   color: white;
-  transition: 0.2s ease;
+  transition: var(--transition-normal);
 }
 
 a.navbar-icon:hover {
@@ -56,12 +116,12 @@ a.navbar-icon b:hover {
 }
 
 .mobile-header {
-  margin-top: 55px;
+  margin-top: var(--navbar-height);
   width: 100%;
   display: flex;
-  background-color: hsl(0, 0%, 10%);
+  background-color: var(--color-bg-secondary);
   position: absolute;
-  box-shadow: 0px 6px 22px 0px rgba(0, 0, 0, 0.22);
+  box-shadow: var(--shadow-lg);
   z-index: 115;
   flex-direction: column;
   animation-duration: 310ms !important;
@@ -81,8 +141,8 @@ a.navbar-icon b:hover {
 .mobile-header .head {
   width: 100%;
   display: flex;
-  padding: 8px 6px 8px 10px;
-  background-color: hsl(0, 0%, 15%);
+  padding: var(--space-sm) 6px var(--space-sm) 10px;
+  background-color: var(--color-bg-elevated);
   cursor: pointer;
 }
 
@@ -116,7 +176,7 @@ a.navbar-icon b:hover {
   padding-top: 8px;
 }
 
-@media (min-width: 767px) {
+@media (min-width: 769px) {
   .mobile-header {
     display: none;
   }
@@ -190,14 +250,14 @@ ripple.logo {
   margin-bottom: -65px;
   display: flex;
   align-items: center;
-  transition: 0.2s ease;
+  transition: var(--transition-normal);
 }
 
 .huge.heading.right .ui.container {
   text-align: right;
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   .huge.heading {
     height: 215px;
   }
@@ -207,7 +267,7 @@ ripple.logo {
   }
 }
 
-@media (min-width: 767px) {
+@media (min-width: 769px) {
   .huge.heading {
     height: 215px;
   }
@@ -218,7 +278,7 @@ ripple.logo {
 }
 
 .huge.heading h1 {
-  color: #f9f9f9;
+  color: var(--color-text-primary);
   text-shadow: 0 2px 10px #000;
 }
 
@@ -350,7 +410,7 @@ body.ds .white.background {
   width: 140px;
 }
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 576px) {
   .user.avatar {
     height: 100px;
     width: 100px;
@@ -396,20 +456,20 @@ body.ds .white.background {
 
 .subtitle,
 .about.title {
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--color-text-secondary);
 }
 
 .subtitle b {
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--color-text-primary);
 }
 
 body.ds .subtitle,
 body.ds .about.title {
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--color-text-secondary);
 }
 
 body.ds .subtitle b {
-  color: rgba(255, 255, 255, 0.94);
+  color: var(--color-text-primary);
 }
 
 .little.margin.top {
@@ -538,7 +598,7 @@ code {
   height: 1.2rem;
 }
 
-@media (max-width: 911px) {
+@media (max-width: 992px) {
   #navbar .item {
     margin: 0 !important;
   }
@@ -551,7 +611,7 @@ code {
   }
 }
 
-@media (max-width: 767px) {
+@media (max-width: 768px) {
   #app.unfocus > div:not(#header):before {
     opacity: 1;
     visibility: visible;
@@ -576,13 +636,13 @@ code {
   margin: 0 auto;
 }
 
-@media (max-width: 720px) {
+@media (max-width: 768px) {
   .tiny.container {
     width: auto;
   }
 }
 
-@media (min-width: 720px) {
+@media (min-width: 769px) {
   .tiny.container {
     width: 720px;
   }
@@ -799,8 +859,9 @@ li.language-select.selected:before {
 }
 
 .akat-box {
-  background: hsl(var(--base), 0%, 12%);
-  padding: 22px;
+  background: var(--color-bg-secondary);
+  padding: var(--space-lg);
+  border-radius: var(--radius-md);
 }
 
 #userpage-content::-webkit-scrollbar,
@@ -829,31 +890,31 @@ body::-webkit-scrollbar-thumb {
 }
 
 .rank-SS {
-  color: #f9c77d;
+  color: var(--color-rank-ss);
 }
 
 .rank-S {
-  color: #f9c77d;
+  color: var(--color-rank-s);
 }
 
 .rank-A {
-  color: #8ef97d;
+  color: var(--color-rank-a);
 }
 
 .rank-B {
-  color: #7dccf9;
+  color: var(--color-rank-b);
 }
 
 .rank-C {
-  color: #d17df9;
+  color: var(--color-rank-c);
 }
 
 .rank-D {
-  color: #f97d84;
+  color: var(--color-rank-d);
 }
 
 .rank-F {
-  color: #f97d7d;
+  color: var(--color-rank-f);
 }
 
 .load-data {
@@ -879,11 +940,11 @@ body::-webkit-scrollbar-thumb {
   pointer-events: none !important;
 }
 
-@media only screen and (min-width: 768px) and (max-width: 991px) {
+@media only screen and (min-width: 769px) and (max-width: 992px) {
   #navbar .item {
     font-size: 0.8rem;
     padding: 0.88571429em 0.52857143em;
-    transition: 0.3s ease;
+    transition: var(--transition-slow);
   }
 
   #navbar .item:hover {
@@ -897,7 +958,7 @@ body::-webkit-scrollbar-thumb {
 }
 
 .tournament-badge {
-  transition: 0.1s ease;
+  transition: var(--transition-fast);
   display: flex;
   justify-content: center;
   align-items: center;
@@ -969,7 +1030,7 @@ body::-webkit-scrollbar-thumb {
   margin-left: 6px !important;
 }
 
-@media only screen and (max-width: 500px) {
+@media only screen and (max-width: 576px) {
   .right--margin {
     margin-left: 0px !important;
     margin-top: 10px !important;

--- a/web/src/css/pages/home.css
+++ b/web/src/css/pages/home.css
@@ -85,15 +85,15 @@ button:focus {
 }
 
 .main-block {
-  border-radius: 4px;
+  border-radius: var(--radius-md);
   display: flex;
   justify-content: center;
-  background-color: hsl(var(--base), 10%, 15%) !important;
+  background-color: var(--color-bg-elevated) !important;
   margin-top: 96px;
   align-items: flex-end;
   height: 288px;
   padding-right: 34px;
-  box-shadow: 0 1px 2px 0 rgb(34 36 38 / 15%);
+  box-shadow: var(--shadow-sm);
 }
 
 .margined.container {

--- a/web/src/css/pages/leaderboard.css
+++ b/web/src/css/pages/leaderboard.css
@@ -20,7 +20,7 @@
 }
 
 .l-player {
-  background: hsl(0, 0%, 18%);
+  background: var(--color-bg-elevated);
 }
 
 .l-player td div a {

--- a/web/src/css/pages/profile.css
+++ b/web/src/css/pages/profile.css
@@ -148,8 +148,8 @@
   flex-direction: column;
   font-size: 20px;
   padding: 11px;
-  background: #292929e3;
-  border-radius: 5px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-md);
   margin-bottom: 4px;
   float: right;
   margin-top: 40%;
@@ -443,7 +443,7 @@
 
 .sui .header-top {
   padding: 16px;
-  background: #292929;
+  background: var(--color-bg-elevated);
 }
 
 .scores {
@@ -460,8 +460,8 @@
   margin: 8px 0;
   justify-content: space-between;
   overflow: hidden;
-  background: hsl(var(--base), 0%, 15%);
-  transition: 0.1s ease;
+  background: var(--color-bg-elevated);
+  transition: var(--transition-fast);
   cursor: pointer;
 }
 
@@ -479,7 +479,7 @@
 
 .map-single:hover {
   transform: scale(1.01);
-  background: hsl(var(--base), 0%, 16%);
+  background: var(--color-bg-hover);
 }
 
 .map-single:first-child {
@@ -608,7 +608,7 @@
 
 .score-data {
   padding: 8px 12px;
-  background: #222121;
+  background: var(--color-bg-secondary);
 }
 
 .achivement-data {
@@ -628,8 +628,8 @@
 
 .show-button {
   padding: 6px 22px;
-  background: hsl(var(--base), 0%, 16%);
-  color: white;
+  background: var(--color-bg-elevated);
+  color: var(--color-text-primary);
   margin: 0px 8px 8px 8px;
   cursor: pointer;
 }
@@ -663,8 +663,8 @@
 
 .badge {
   padding: 3px 11px;
-  background: #292929e3;
-  border-radius: 5px;
+  background: var(--color-bg-elevated);
+  border-radius: var(--radius-sm);
   margin-bottom: 4px;
 }
 

--- a/web/src/css/semantic.css
+++ b/web/src/css/semantic.css
@@ -11773,10 +11773,10 @@ ol.ui.list li[value]:before {
 
 .ui.segment {
   position: relative;
-  background: #222121;
+  background: var(--color-bg-secondary);
   margin: 1rem 0;
   padding: 1em;
-  border-radius: 0.28571429rem;
+  border-radius: var(--radius-md);
 }
 
 .ui.segment:first-child {


### PR DESCRIPTION
## Summary
Updates profile.css and home.css to use the CSS custom properties defined in phase1 for consistent background colors across the site.

⚠️ **Depends on #217 (ui/phase1-css-foundation) being merged first** - the CSS variables referenced here are defined in that PR.

## Changes

**profile.css:**
- `.profile-rank-container` - uses `--color-bg-elevated`, `--radius-md`
- `.sui .header-top` - uses `--color-bg-elevated`
- `.map-single` - uses `--color-bg-elevated`, `--transition-fast`
- `.map-single:hover` - uses `--color-bg-hover`
- `.score-data` - uses `--color-bg-secondary`
- `.show-button` - uses `--color-bg-elevated`, `--color-text-primary`
- `.badge` - uses `--color-bg-elevated`, `--radius-sm`

**home.css:**
- `.main-block` - uses `--color-bg-elevated`, `--radius-md`, `--shadow-sm`

## Test plan
- [ ] Merge #217 first
- [ ] Test profile page - score cards, badges, rank container
- [ ] Test homepage - main block styling
- [ ] Verify consistent appearance across pages

🤖 Generated with [Claude Code](https://claude.ai/code)