### PR TITLE
Fix dropdown button flicker on beatmap page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,31 @@
+# CLAUDE.md - Hanayo
+
+## Development Server
+
+**IMPORTANT**: Always use `./run-server.sh` or restart the full server after any asset changes. Never run `gulp` alone without restarting the server.
+
+Hanayo uses content-hashed asset filenames (e.g., `akatsuki-cd83ec9f8f.min.css`), and the Go binary reads the asset manifest at startup. Running only `gulp` will generate new hashed filenames, but the running server will still reference the old hashes, causing 404s for all JS/CSS.
+
+```bash
+# Preferred: builds assets, Go binary, signs, and starts server
+./run-server.sh
+
+# If you need to rebuild manually, always restart the server after:
+cd web && gulp && cd ..
+go build -o hanayo .
+./hanayo
+```
+
+## Project Structure
+
+- `app/handlers/` - HTTP request handlers (profiles, beatmaps, clans, sessions, etc.)
+- `app/usecases/` - Business logic (auth, templates, user management)
+- `app/middleware/` - Rate limiting, logging, blacklist
+- `app/models/` - Data models (session, pages, messages)
+- `app/states/` - Application state (settings, services)
+- `internal/` - Internal utilities (CSRF, BBCode, locale)
+- `web/templates/` - Go HTML templates
+- `web/src/css/` - Source CSS files
+- `web/src/js/` - Source JavaScript files
+- `web/static/` - Compiled static assets (output of gulp)
+- `main.go` - Server setup with Gin router

--- a/web/src/css/akatsuki.css
+++ b/web/src/css/akatsuki.css
@@ -1137,18 +1137,18 @@ body::-webkit-scrollbar-thumb {
   background: hsl(0, 0%, 15%) !important;
 }
 
-/* Modern button hover effects */
-.ui.button:not(.disabled):not(.loading) {
+/* Modern button hover effects (exclude dropdowns to prevent menu misalignment) */
+.ui.button:not(.disabled):not(.loading):not(.dropdown) {
   transition: transform 0.15s ease,
               box-shadow 0.15s ease,
               background-color 0.15s ease;
 }
 
-.ui.button:not(.disabled):not(.loading):hover {
+.ui.button:not(.disabled):not(.loading):not(.dropdown):hover {
   transform: translateY(-1px);
 }
 
-.ui.button:not(.disabled):not(.loading):active {
+.ui.button:not(.disabled):not(.loading):not(.dropdown):active {
   transform: translateY(0);
 }
 


### PR DESCRIPTION
## Summary
- Exclude dropdown buttons from the `translateY(-1px)` hover effect that was causing the difficulty selector to flicker on beatmap pages
- Add CLAUDE.md with development instructions (notably: always restart server after asset changes due to content hashing)

## Test plan
- [ ] Visit a beatmap page (e.g., `/b/1556336`)
- [ ] Hover over the difficulty dropdown - should not flicker
- [ ] Verify other buttons still have the subtle hover effect

🤖 Generated with [Claude Code](https://claude.ai/code)