### PR TITLE
Add fade-up animation to homepage mode selector

### DIFF
--- a/web/src/css/pages/home.css
+++ b/web/src/css/pages/home.css
@@ -573,6 +573,10 @@
   animation: fade-up 0.6s ease-out 0.1s backwards;
 }
 
+.mode-selector-bar {
+  animation: fade-up 0.6s ease-out 0.15s backwards;
+}
+
 .activity-card,
 .trending-card {
   animation: fade-up 0.6s ease-out 0.2s backwards;


### PR DESCRIPTION
## Summary
- Apply fade-up animation to mode selector buttons on homepage
- Staggered timing (0.15s delay) maintains consistent visual flow
- Matches the existing animation sequence of other page elements

## Context
Previously, when the homepage loaded, all elements animated in with a fade-up effect except the mode selector buttons. This PR adds the same animation to the mode selectors to create a cohesive loading experience.

## Test plan
- [x] Visit homepage and observe smooth fade-up animation
- [x] Verify mode selector buttons animate in sequence with other elements
- [x] Check that timing feels natural (hero → stats → modes → content)

🤖 Generated with [Claude Code](https://claude.ai/code)