### PR TITLE
Add mode filtering for achievements on profile page

### DIFF
--- a/web/src/js/pages/profile.js
+++ b/web/src/js/pages/profile.js
@@ -151,6 +151,7 @@ $(document).ready(function () {
       `${wl.pathname}?mode=${m}&rx=${preferRelax}${wl.hash}`
     );
     initialiseChartGraph(graphType, true);
+    initialiseAchievements();
   });
   initialiseAchievements();
   initialiseUserpage();
@@ -551,7 +552,7 @@ function initialiseUserpage() {
 function initialiseAchievements() {
   api(
     "users/achievements" + (currentUserID == userID ? "?all" : ""),
-    { id: userID },
+    { id: userID, mode: favouriteMode },
     function (resp) {
       var achievements = resp.achievements;
       // no achievements -- show default message

--- a/web/src/js/pages/profile.js
+++ b/web/src/js/pages/profile.js
@@ -557,7 +557,7 @@ function initialiseAchievements() {
       var achievements = resp.achievements;
       // no achievements -- show default message
       if (achievements.length === 0) {
-        $("#achievements").append(
+        $("#achievements").empty().append(
           $(
             `<div class='ui sixteen wide column'>
             <div class="empty-state">
@@ -620,6 +620,7 @@ function initialiseAchievements() {
       } else {
         $("#load-more-achievements")
           .removeClass("disabled")
+          .off("click")
           .on("click", function () {
             $(this).remove();
             displayAchievements(-1, false);


### PR DESCRIPTION
## Summary

Adds mode-specific achievement filtering to the profile page, completing the frontend portion of Sprint 4.

## Changes

1. **Pass mode parameter to API**: Updated `initialiseAchievements()` to include the current `favouriteMode` when calling the achievements API
2. **Reload on mode switch**: Added `initialiseAchievements()` call when user clicks mode switcher, ensuring achievements update to match the selected mode

## Dependencies

- Requires akatsuki-api PR #92 (backend mode filtering support)
- Part of achievement system refactor Sprint 4

## Test Plan

1. Visit user profile page
2. Switch between game modes (std, taiko, catch, mania)
3. Verify achievements update to show only those earned in the selected mode
4. Test with `?all` parameter on own profile to ensure unearned achievements still show

## Related

- Sprint 4: Frontend + API mode support
- akatsuki-api PR: #92