### PR TITLE
Fix locked achievements not showing on mode switch

### DIFF
--- a/web/src/js/pages/profile.js
+++ b/web/src/js/pages/profile.js
@@ -639,7 +639,7 @@ function initialiseAchievements() {
             displayAchievements(-1, false);
           });
       }
-      displayAchievements(8, true);
+      displayAchievements(8, false);
     }
   );
 }


### PR DESCRIPTION
## Summary

When switching game modes on profile pages, only unlocked achievements were displayed if the user had at least one achievement in that mode. This was due to the `achievedOnly=true` parameter in the initial display call.

The fallback logic that would show all achievements only triggered when **zero** achievements were shown. If a user had even 1-2 unlocked achievements in the new mode, locked achievements would remain hidden.

## Changes

- Changed `displayAchievements(8, true)` to `displayAchievements(8, false)` in hanayo/web/src/js/pages/profile.js:642
- Now consistently shows both locked and unlocked achievements when switching modes

## Testing

- [x] Initial page load shows locked + unlocked achievements
- [x] Switching between std/taiko/catch/mania shows correct locked + unlocked achievements for each mode
- [x] "Load more" button still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)