### PR TITLE
Persist Load more button when switching modes

### DIFF
--- a/web/src/js/pages/profile.js
+++ b/web/src/js/pages/profile.js
@@ -624,18 +624,17 @@ function initialiseAchievements() {
         }
       };
 
-      // only 8 achievements - we can remove the button completely, because
-      // it won't be used (no more achievements).
-      // otherwise, we simply remove the disabled class and add the click handler
-      // to activate it.
+      // only 8 achievements - hide the button
+      // otherwise, show the button and add the click handler
       if (achievements.length <= 8) {
-        $("#load-more-achievements").remove();
+        $("#load-more-achievements").hide();
       } else {
         $("#load-more-achievements")
+          .show()
           .removeClass("disabled")
           .off("click")
           .on("click", function () {
-            $(this).remove();
+            $(this).hide();
             displayAchievements(-1, false);
           });
       }


### PR DESCRIPTION
## Summary

After clicking "Load more" on one game mode and then switching to another mode, the "Load more" button would not appear on the new mode. This was because the button was permanently removed from the DOM with `.remove()`.

## Changes

- Changed `.remove()` to `.hide()` / `.show()` so the button persists in the DOM
- Button is now shown/hidden based on whether there are more than 8 achievements for each mode

## Testing

- [x] Visit profile → see 8 achievements + "Load more" button
- [x] Click "Load more" → see all achievements, button is hidden
- [x] Switch modes → see 8 achievements for new mode + "Load more" button reappears
- [x] Click "Load more" again → see all achievements for that mode
- [x] Continue switching modes → button correctly appears/disappears based on achievement count

🤖 Generated with [Claude Code](https://claude.com/claude-code)