### PR TITLE
Reload achievements when switching rx/ap modes

### DIFF
--- a/web/src/js/pages/profile.js
+++ b/web/src/js/pages/profile.js
@@ -115,6 +115,7 @@ $(document).ready(function () {
     );
     initialiseChartGraph(graphType, true);
     applyPeakRankLabel();
+    initialiseAchievements();
   });
 
   // when an item in the mode menu is clicked, it means we should change the mode.


### PR DESCRIPTION
## Summary

When switching between vanilla/relax/autopilot modes, achievements were not reloading to show the correct achievements for that mode combination. Only switching game modes (std/taiko/catch/mania) would reload achievements.

## Changes

- Added `initialiseAchievements()` call to the rx-menu click handler
- Now achievements reload when switching between vanilla (rx=0), relax (rx=1), and autopilot (rx=2) modes
- Matches the behavior of the game mode switcher which already calls `initialiseAchievements()`

## Testing

- [x] Switch between vanilla/relax/autopilot → achievements reload for each mode
- [x] Switch game modes → achievements still reload correctly
- [x] Combined switches (change mode then rx) → all work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)