### PR TITLE
Add health endpoint and HTTP readiness probe

### DIFF
--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -13,7 +13,8 @@ apps:
         tag: latest
       port: 80
       readinessProbe:
-        tcpSocket:
+        httpGet:
+          path: /_health
           port: 80
         initialDelaySeconds: 5
         periodSeconds: 10

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -12,6 +12,14 @@ apps:
         repository: osuakatsuki/hanayo
         tag: latest
       port: 80
+      readinessProbe:
+        tcpSocket:
+          port: 80
+        initialDelaySeconds: 5
+        periodSeconds: 10
+        timeoutSeconds: 2
+        successThreshold: 1
+        failureThreshold: 3
       env:
         - name: APP_COMPONENT
           value: api

--- a/main.go
+++ b/main.go
@@ -189,6 +189,10 @@ func generateEngine() *gin.Engine {
 	r.Static("/static", "web/static")
 	r.StaticFile("/favicon.ico", "web/static/favicon.ico")
 
+	r.GET("/_health", func(c *gin.Context) {
+		c.String(200, "ok")
+	})
+
 	r.POST("/login", loginHandlers.LoginSubmitHandler)
 	r.GET("/logout", logoutHandlers.LogoutSubmitHandler)
 


### PR DESCRIPTION
## Summary
- Add `/_health` Gin route that returns 200 OK
- Switch readiness probe from TCP to HTTP for proper health checking
- Required for Kyverno policy compliance (require-probes)

## Test plan
- [ ] Verify `/_health` endpoint returns 200 OK
- [ ] Verify readiness probe works in Kubernetes

🤖 Generated with [Claude Code](https://claude.com/claude-code)