### PR TITLE
Update trending section dynamically on mode/rx switch

### DIFF
--- a/app/handlers/misc/homepage_api.go
+++ b/app/handlers/misc/homepage_api.go
@@ -72,8 +72,17 @@ func HomepageActivityHandler(c *gin.Context) {
 		json.Unmarshal([]byte(highPPRaw.Val()), &highPP)
 	}
 
+	// Fetch trending beatmaps from Redis
+	trendingKey := fmt.Sprintf("akatsuki:trending_beatmaps:%d", combinedMode)
+	trendingRaw := services.RD.Get(trendingKey)
+	var trending []map[string]interface{}
+	if trendingRaw != nil && trendingRaw.Err() == nil {
+		json.Unmarshal([]byte(trendingRaw.Val()), &trending)
+	}
+
 	c.JSON(http.StatusOK, gin.H{
 		"first_places": firstPlaces,
 		"high_pp":      highPP,
+		"trending":     trending,
 	})
 }

--- a/web/src/js/pages/home.js
+++ b/web/src/js/pages/home.js
@@ -187,6 +187,50 @@ function renderActivityContent(container, items, type) {
   $(".new.timeago").timeago().removeClass("new");
 }
 
+// Render trending maps into container
+function renderTrending(container, items) {
+  container.replaceChildren();
+  if (!items || items.length === 0) {
+    const p = document.createElement('p');
+    p.className = 'no-activity';
+    p.textContent = 'No trending maps';
+    container.appendChild(p);
+    return;
+  }
+  items.forEach(item => {
+    const beatmapId = Math.floor(item.beatmap_id);
+    const beatmapsetId = Math.floor(item.beatmapset_id);
+    const playCount = Math.floor(item.play_count);
+
+    const a = document.createElement('a');
+    a.href = `/b/${beatmapId}`;
+    a.className = 'trending-map';
+
+    const img = document.createElement('img');
+    img.src = `https://assets.ppy.sh/beatmaps/${beatmapsetId}/covers/card.jpg`;
+    img.className = 'trending-bg';
+    img.loading = 'lazy';
+    img.alt = '';
+    a.appendChild(img);
+
+    const overlay = document.createElement('div');
+    overlay.className = 'trending-overlay';
+
+    const name = document.createElement('span');
+    name.className = 'trending-name';
+    name.textContent = item.song_name;
+    overlay.appendChild(name);
+
+    const plays = document.createElement('span');
+    plays.className = 'trending-plays';
+    plays.textContent = `${playCount} plays`;
+    overlay.appendChild(plays);
+
+    a.appendChild(overlay);
+    container.appendChild(a);
+  });
+}
+
 // Fetch and update activity data
 async function updateActivityData() {
   try {
@@ -203,6 +247,11 @@ async function updateActivityData() {
     const highPPEl = document.getElementById('high-pp');
     if (highPPEl) {
       renderActivityContent(highPPEl, data.high_pp, 'high-pp');
+    }
+
+    const trendingEl = document.getElementById('trending-grid');
+    if (trendingEl) {
+      renderTrending(trendingEl, data.trending);
     }
   } catch (error) {
     console.error('Error fetching activity data:', error);

--- a/web/templates/homepage.html
+++ b/web/templates/homepage.html
@@ -151,7 +151,7 @@
       <div class="trending-column">
         <div class="trending-card">
           <h3 class="trending-title">Trending This Week</h3>
-          <div class="trending-grid">
+          <div class="trending-grid" id="trending-grid">
             {{ range redigetJSON "akatsuki:trending_beatmaps" }}
               <a href="/b/{{ ftoi .beatmap_id }}" class="trending-map">
                 <img


### PR DESCRIPTION
## Summary
- Add trending beatmaps to the `/api/v1/homepage/activity` response (reads `akatsuki:trending_beatmaps:{combinedMode}` from Redis)
- Add `renderTrending()` JS function to rebuild the trending grid client-side on mode/rx change
- Add `id="trending-grid"` to the template so JS can target the container

Depends on osuAkatsuki/new-cron PR for per-mode Redis keys.

## Test plan
- [ ] Homepage loads with trending maps for default mode (vn std)
- [ ] Switching rx mode (Vanilla/Relax/Autopilot) updates the trending section
- [ ] Switching game mode (osu!/Taiko/Catch/Mania) updates the trending section
- [ ] "No trending maps" fallback renders when a mode has no data
- [ ] Trending map links navigate to correct beatmap pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)