### PR TITLE
add missing return after Resp403 in password handlers

### DIFF
--- a/app/handlers/profiles/settings/password.go
+++ b/app/handlers/profiles/settings/password.go
@@ -23,6 +23,7 @@ func ChangePasswordPageHandler(c *gin.Context) {
 	ctx := sessions.GetContext(c)
 	if ctx.User.ID == 0 {
 		tu.Resp403(c)
+		return
 	}
 	s, err := services.QB.QueryRow("SELECT email FROM users WHERE id = ?", ctx.User.ID)
 	if err != nil {
@@ -39,6 +40,7 @@ func ChangePasswordSubmitHandler(c *gin.Context) {
 	ctx := sessions.GetContext(c)
 	if ctx.User.ID == 0 {
 		tu.Resp403(c)
+		return
 	}
 	defer func() {
 		s, err := services.QB.QueryRow("SELECT email FROM users WHERE id = ?", ctx.User.ID)


### PR DESCRIPTION
Fixes #247

Without the return, unauthenticated requests fall through the auth check and continue executing with user ID 0.