### PR TITLE
block protocol-relative URLs in login redirect

### DIFF
--- a/app/handlers/sessions/login/login.go
+++ b/app/handlers/sessions/login/login.go
@@ -129,7 +129,7 @@ func LoginSubmitHandler(c *gin.Context) {
 	AfterLogin(c, data.ID, data.Country)
 
 	redir := c.PostForm("redir")
-	if len(redir) > 0 && redir[0] != '/' {
+	if len(redir) > 0 && (redir[0] != '/' || strings.HasPrefix(redir, "//")) {
 		redir = ""
 	}
 


### PR DESCRIPTION
Fixes #248

Added a check for // prefix so redir=//evil.com gets rejected.