### PR TITLE
fix private match access check boolean logic

### DIFF
--- a/app/handlers/multiplayer/multiplayer.go
+++ b/app/handlers/multiplayer/multiplayer.go
@@ -94,7 +94,7 @@ func MultiplayerHistoryHandler(c *gin.Context) {
 	}
 
 	if privateMatch &&
-		(!inList(participantsIds, ctx.User.ID) ||
+		(!inList(participantsIds, ctx.User.ID) &&
 			ctx.User.Privileges&common.UserPrivilegeTournamentStaff == 0) {
 		data.MatchID = 0
 		data.TitleBar = lu.T(c, "Match not found.")


### PR DESCRIPTION
Fixes #249

Changed || to && so access is denied only when the user is neither a participant nor tournament staff.