### PR TITLE
use = instead of LIKE for email lookups

### DIFF
--- a/app/handlers/profiles/settings/password.go
+++ b/app/handlers/profiles/settings/password.go
@@ -75,7 +75,7 @@ func ChangePasswordSubmitHandler(c *gin.Context) {
 	services.DB.Get(&currentEmail, "SELECT email FROM users WHERE id = ?", ctx.User.ID)
 
 	if email != "" && email != currentEmail {
-		if services.DB.QueryRow("SELECT 1 FROM users WHERE email LIKE ?", email).
+		if services.DB.QueryRow("SELECT 1 FROM users WHERE email = ?", email).
 			Scan(new(int)) != sql.ErrNoRows {
 			messages = append(messages, msg.ErrorMessage{lu.T(c, "This email is already in use!")})
 			return

--- a/app/handlers/sessions/register/register.go
+++ b/app/handlers/sessions/register/register.go
@@ -113,7 +113,7 @@ func RegisterSubmitHandler(c *gin.Context) {
 	}
 
 	// check whether an user with that email already exists
-	if services.DB.QueryRow("SELECT 1 FROM users WHERE email LIKE ?", email).
+	if services.DB.QueryRow("SELECT 1 FROM users WHERE email = ?", email).
 		Scan(new(int)) != sql.ErrNoRows {
 		registerResp(c, msg.ErrorMessage{lu.T(c, "An user with that email address already exists!")})
 		return


### PR DESCRIPTION
Fixes #250

LIKE treats % and _ as wildcards which can cause false positives on email uniqueness checks.