### PR TITLE
Fix profile background cache busting

### DIFF
--- a/app/handlers/profiles/profile.go
+++ b/app/handlers/profiles/profile.go
@@ -68,11 +68,12 @@ func UserProfilePageHandler(c *gin.Context) {
 		var profileBackground struct {
 			Type  int
 			Value string
+			Time  int64
 		}
-		services.DB.Get(&profileBackground, "SELECT type, value FROM profile_backgrounds WHERE uid = ?", data.UserID)
+		services.DB.Get(&profileBackground, "SELECT type, value, time FROM profile_backgrounds WHERE uid = ?", data.UserID)
 		switch profileBackground.Type {
 		case 1, 3:
-			data.BannerContent = fmt.Sprintf("%s/profile-backgrounds/%s", settings.PUBLIC_AVATARS_SERVICE_BASE_URL, profileBackground.Value)
+			data.BannerContent = fmt.Sprintf("%s/profile-backgrounds/%s?v=%d", settings.PUBLIC_AVATARS_SERVICE_BASE_URL, profileBackground.Value, profileBackground.Time)
 			data.BannerAbsolute = true
 			data.BannerType = profileBackground.Type
 		case 2:

--- a/app/handlers/profiles/settings/profbackground.go
+++ b/app/handlers/profiles/settings/profbackground.go
@@ -5,19 +5,19 @@ import (
 	"image"
 	"image/gif"
 	"image/jpeg"
+	"io"
 	"os"
 	"regexp"
 	"strings"
 	"time"
-	"io"
 
 	"golang.org/x/exp/slog"
 
-	"github.com/gin-gonic/gin"
-	"github.com/osuAkatsuki/hanayo/app/models"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/gin-gonic/gin"
+	"github.com/osuAkatsuki/hanayo/app/models"
 	msg "github.com/osuAkatsuki/hanayo/app/models/messages"
 	"github.com/osuAkatsuki/hanayo/app/sessions"
 	"github.com/osuAkatsuki/hanayo/app/states/services"
@@ -49,7 +49,7 @@ func ProfileBackgroundSubmitHandler(c *gin.Context) {
 	t := c.Param("type")
 	switch t {
 	case "0":
-		services.DB.Exec("DELETE FROM profile_backgrounds WHERE uid = ?", ctx.User.ID)
+		saveProfileBackground(ctx, 0, "")
 	case "1":
 		// image
 		file, _, err := c.Request.FormFile("value")
@@ -176,7 +176,7 @@ func saveProfileBackground(ctx models.Context, t int, val string) {
 	services.DB.Exec(`INSERT INTO profile_backgrounds(uid, time, type, value)
 		VALUES (?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
-			time = VALUES(time),
+			time = GREATEST(VALUES(time), time + 1),
 			type = VALUES(type),
 			value = VALUES(value)
 	`, ctx.User.ID, time.Now().Unix(), t, val)

--- a/web/src/js/akatsuki_src.js
+++ b/web/src/js/akatsuki_src.js
@@ -589,7 +589,7 @@ var singlePageSnippets = {
       $("[data-type]:not([hidden])").attr("hidden", "hidden");
       $("[data-type=" + $(this).val() + "]").removeAttr("hidden");
     });
-    $("#file").change(function (e) {
+    function previewBackground(e, target) {
       var f = e.target.files;
       if (f.length < 1) {
         return;
@@ -600,7 +600,13 @@ var singlePageSnippets = {
       i.onload = function () {
         window.URL.revokeObjectURL(this.src);
       };
-      $("#image-background").empty().append(i);
+      $(target).empty().append(i);
+    }
+    $("#file").change(function (e) {
+      previewBackground(e, "#image-background");
+    });
+    $("#giffile").change(function (e) {
+      previewBackground(e, "#gif-background");
     });
   },
 

--- a/web/templates/settings/profbackground.html
+++ b/web/templates/settings/profbackground.html
@@ -15,9 +15,11 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/jquery-minicolors/2.2.4/jque
       {{ template "settingsSidebar" . }}
       <div class="twelve wide column">
         <div class="ui center aligned segment">
-          {{ $d := qb "SELECT type, value FROM profile_backgrounds WHERE uid = ? LIMIT 1" .Context.User.ID }}
-          {{ $type  := or $d.type.Int -1 }}
+          {{ $d := qb "SELECT 1 AS has_background, type, value, time FROM profile_backgrounds WHERE uid = ? LIMIT 1" .Context.User.ID }}
+          {{ $type  := -1 }}
+          {{ if $d.has_background.Int }}{{ $type = $d.type.Int }}{{ end }}
           {{ $value := or $d.value.String "" }}
+          {{ $time  := or $d.time.Int 0 }}
           <p>
             <select class="ui dropdown" id="background-type" name="type">
               <option value="">{{ .T "Background type" }}</option>
@@ -43,7 +45,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/jquery-minicolors/2.2.4/jque
             {{ if ne $type 1 }}hidden{{ end }}>
             {{ if and (eq $type 1) $value }}
               <img
-                src="{{ .Conf.PUBLIC_AVATARS_SERVICE_BASE_URL }}/profile-backgrounds/{{ $value }}" />
+                src="{{ .Conf.PUBLIC_AVATARS_SERVICE_BASE_URL }}/profile-backgrounds/{{ $value }}?v={{ $time }}" />
             {{ else }}
               No image selected
             {{ end }}
@@ -56,7 +58,7 @@ AdditionalJS=https://cdnjs.cloudflare.com/ajax/libs/jquery-minicolors/2.2.4/jque
             {{ if ne $type 3 }}hidden{{ end }}>
             {{ if and (eq $type 3) $value }}
               <img
-                src="{{ .Conf.PUBLIC_AVATARS_SERVICE_BASE_URL }}/profile-backgrounds/{{ $value }}" />
+                src="{{ .Conf.PUBLIC_AVATARS_SERVICE_BASE_URL }}/profile-backgrounds/{{ $value }}?v={{ $time }}" />
             {{ else }}
               No image selected
             {{ end }}


### PR DESCRIPTION
## Summary
- append the profile background row timestamp to rendered image/GIF URLs so cached assets are invalidated after updates
- preserve a type-0 profile background row and monotonically bump the version to handle rapid None -> upload flows
- add local GIF preview handling on the profile background settings page

Fixes #261.

## Testing
- `go test ./app/handlers/profiles/...`
- `node --check web/src/js/akatsuki_src.js`
- `go run /tmp/check_hanayo_templates.go`
- `go test ./...` currently fails in unrelated packages: `internal/bbcode` panics in `parseTwitch`, and `internal/csrf/cieca` aborts on macOS with missing `LC_UUID`.
