### PR TITLE
Make connection link state explicit

### DIFF
--- a/web/templates/settings/connections.html
+++ b/web/templates/settings/connections.html
@@ -14,8 +14,8 @@ MinPrivileges=2
       {{ template "settingsSidebar" . }}
       <div class="twelve wide column">
         <div class="ui segment">
-          {{ $q := qb "SELECT discord_account_id, twitch_account_id, twitch_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
-          {{ if $q.discord_account_id }}
+          {{ $q := qb "SELECT discord_account_id IS NOT NULL AS discord_linked, twitch_account_id IS NOT NULL AS twitch_linked, twitch_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
+          {{ if $q.discord_linked.Bool }}
             <p>
               {{ .T "Your Discord account is already linked with us. If you wish to unlink your Discord, please use the button below." }}
             </p>
@@ -43,7 +43,7 @@ MinPrivileges=2
             </p>
           {{ end }}
           <div class="ui divider"></div>
-          {{ if $q.twitch_account_id }}
+          {{ if $q.twitch_linked.Bool }}
             <p>
               {{ .T "Your Twitch account is already linked with us as %s. If you wish to unlink your Twitch account, please use the button below." $q.twitch_username }}
             </p>


### PR DESCRIPTION
## Summary
- render Discord and Twitch connection state from explicit SQL booleans
- keep the two link/unlink sections independent in the settings connections page

## Verification
- git diff --check
- go test ./app/handlers/connections ./app/states/settings -run TestNonExistent