### PR TITLE
Add OAuth state to connection link flows

### DIFF
--- a/app/handlers/connections/discord.go
+++ b/app/handlers/connections/discord.go
@@ -5,12 +5,15 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
+	eh "github.com/osuAkatsuki/hanayo/app/handlers/errors"
 	"github.com/osuAkatsuki/hanayo/app/sessions"
 	tu "github.com/osuAkatsuki/hanayo/app/usecases/templates"
 
 	lu "github.com/osuAkatsuki/hanayo/app/usecases/localisation"
+	"github.com/osuAkatsuki/hanayo/app/usecases/oauthstate"
 
 	msg "github.com/osuAkatsuki/hanayo/app/models/messages"
 
@@ -34,11 +37,26 @@ func LinkDiscordHandler(c *gin.Context) {
 	}
 
 	settings := settingsState.GetSettings()
+	state, err := oauthstate.New(
+		"discord",
+		int(sessions.GetContext(c).User.ID),
+		settings.APP_HANAYO_KEY,
+		time.Now().Add(10*time.Minute),
+	)
+	if err != nil {
+		eh.Resp500(c)
+		return
+	}
 
 	discordCallbackUrl := fmt.Sprintf("%s/discord/callback", settings.PUBLIC_AKATSUKI_API_BASE_URL)
-	redirectUrl := fmt.Sprintf("https://discord.com/oauth2/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=identify", settings.DISCORD_CLIENT_ID, discordCallbackUrl)
+	query := url.Values{}
+	query.Set("client_id", settings.DISCORD_CLIENT_ID)
+	query.Set("redirect_uri", discordCallbackUrl)
+	query.Set("response_type", "code")
+	query.Set("scope", "identify")
+	query.Set("state", state)
 
-	c.Redirect(301, redirectUrl)
+	c.Redirect(301, "https://discord.com/oauth2/authorize?"+query.Encode())
 }
 
 func LinkTwitchHandler(c *gin.Context) {
@@ -57,11 +75,23 @@ func LinkTwitchHandler(c *gin.Context) {
 	}
 
 	settings := settingsState.GetSettings()
+	state, err := oauthstate.New(
+		"twitch",
+		int(sessions.GetContext(c).User.ID),
+		settings.APP_HANAYO_KEY,
+		time.Now().Add(10*time.Minute),
+	)
+	if err != nil {
+		eh.Resp500(c)
+		return
+	}
+
 	twitchCallbackUrl := fmt.Sprintf("%s/twitch/callback", settings.PUBLIC_AKATSUKI_API_BASE_URL)
 	query := url.Values{}
 	query.Set("client_id", settings.TWITCH_CLIENT_ID)
 	query.Set("redirect_uri", twitchCallbackUrl)
 	query.Set("response_type", "code")
+	query.Set("state", state)
 
 	c.Redirect(301, "https://id.twitch.tv/oauth2/authorize?"+query.Encode())
 }

--- a/app/handlers/connections/discord.go
+++ b/app/handlers/connections/discord.go
@@ -56,7 +56,7 @@ func LinkDiscordHandler(c *gin.Context) {
 	query.Set("scope", "identify")
 	query.Set("state", state)
 
-	c.Redirect(301, "https://discord.com/oauth2/authorize?"+query.Encode())
+	c.Redirect(302, "https://discord.com/oauth2/authorize?"+query.Encode())
 }
 
 func LinkTwitchHandler(c *gin.Context) {
@@ -93,5 +93,5 @@ func LinkTwitchHandler(c *gin.Context) {
 	query.Set("response_type", "code")
 	query.Set("state", state)
 
-	c.Redirect(301, "https://id.twitch.tv/oauth2/authorize?"+query.Encode())
+	c.Redirect(302, "https://id.twitch.tv/oauth2/authorize?"+query.Encode())
 }

--- a/app/usecases/oauthstate/oauth_state.go
+++ b/app/usecases/oauthstate/oauth_state.go
@@ -1,0 +1,44 @@
+package oauthstate
+
+import (
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"time"
+)
+
+type OAuthState struct {
+	Provider  string `json:"provider"`
+	UserID    int    `json:"user_id"`
+	ExpiresAt int64  `json:"expires_at"`
+	Nonce     string `json:"nonce"`
+}
+
+func New(provider string, userID int, secret string, expiresAt time.Time) (string, error) {
+	nonce := make([]byte, 16)
+	if _, err := rand.Read(nonce); err != nil {
+		return "", err
+	}
+
+	payload, err := json.Marshal(OAuthState{
+		Provider:  provider,
+		UserID:    userID,
+		ExpiresAt: expiresAt.Unix(),
+		Nonce:     base64.RawURLEncoding.EncodeToString(nonce),
+	})
+	if err != nil {
+		return "", err
+	}
+
+	encodedPayload := base64.RawURLEncoding.EncodeToString(payload)
+	signedValue := "v1." + encodedPayload
+	return signedValue + "." + base64.RawURLEncoding.EncodeToString(sign(signedValue, secret)), nil
+}
+
+func sign(value string, secret string) []byte {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(value))
+	return mac.Sum(nil)
+}

--- a/app/usecases/oauthstate/oauth_state_test.go
+++ b/app/usecases/oauthstate/oauth_state_test.go
@@ -1,0 +1,48 @@
+package oauthstate
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNew(t *testing.T) {
+	rawState, err := New("discord", 123, "secret", time.Unix(200, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	parts := strings.Split(rawState, ".")
+	if len(parts) != 3 || parts[0] != "v1" {
+		t.Fatalf("invalid state format: %s", rawState)
+	}
+
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var state OAuthState
+	if err := json.Unmarshal(payloadBytes, &state); err != nil {
+		t.Fatal(err)
+	}
+
+	if state.Provider != "discord" || state.UserID != 123 || state.ExpiresAt != 200 || state.Nonce == "" {
+		t.Fatalf("unexpected state payload: %+v", state)
+	}
+
+	signature, err := base64.RawURLEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mac := hmac.New(sha256.New, []byte("secret"))
+	mac.Write([]byte(parts[0] + "." + parts[1]))
+	if !hmac.Equal(signature, mac.Sum(nil)) {
+		t.Fatal("state signature did not match")
+	}
+}


### PR DESCRIPTION
## Summary
- generate short-lived signed OAuth state values for Discord and Twitch link requests
- include state in the provider authorization URL
- use the existing shared Hanayo/API secret so callbacks can validate state without new storage

## Provider support checked
- Discord docs support and recommend state for OAuth2 CSRF protection
- Twitch authorization-code docs support and strongly encourage state for CSRF protection

## Tests
- go test ./app/usecases/oauthstate ./app/handlers/connections