### PR TITLE
Redesign connections settings page

### DIFF
--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - redesign-connections-page
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/production-deploy.yml
+++ b/.github/workflows/production-deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - redesign-connections-page
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/web/src/css/akatsuki.css
+++ b/web/src/css/akatsuki.css
@@ -1165,6 +1165,200 @@ body::-webkit-scrollbar-thumb {
   vertical-align: -.25em;
 }
 
+.connections-section + .connections-section {
+  margin-top: 24px;
+}
+
+.connections-section h3 {
+  margin: 0 0 12px;
+  font-size: 1.1rem;
+}
+
+.connections-card-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.connection-card,
+.connection-add-row {
+  background: hsl(var(--base), 0%, 12%);
+  border: 1px solid hsl(var(--base), 0%, 20%);
+  border-radius: 8px;
+}
+
+.connection-card {
+  min-width: 0;
+  padding: 16px;
+  border-top: 3px solid var(--connection-brand);
+}
+
+.connection-card-header,
+.connection-provider,
+.connection-identity,
+.connection-actions,
+.connection-add-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+.connection-card-header,
+.connection-add-row {
+  justify-content: space-between;
+  gap: 14px;
+}
+
+.connection-provider,
+.connection-identity,
+.connection-actions {
+  gap: 10px;
+}
+
+.connection-provider {
+  color: #fff;
+  font-weight: 700;
+}
+
+.connection-provider-mark {
+  display: inline-flex;
+  width: 30px;
+  height: 30px;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: var(--connection-brand);
+  color: #fff;
+  font-size: 16px;
+}
+
+.connection-provider-mark img {
+  width: 20px;
+  height: 20px;
+  object-fit: contain;
+}
+
+.connection-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  color: #a8f0bd;
+  font-size: .85rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.connection-status::before {
+  content: "";
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #54d878;
+}
+
+.connection-identity {
+  margin-top: 16px;
+}
+
+.connection-avatar {
+  width: 52px;
+  height: 52px;
+  flex: 0 0 auto;
+  overflow: hidden;
+  border-radius: 10px;
+  background: hsl(var(--base), 0%, 16%);
+}
+
+.connection-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.connection-provider-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--connection-brand);
+  font-size: 26px;
+}
+
+.connection-identity-copy,
+.connection-add-copy {
+  min-width: 0;
+}
+
+.connection-identity-copy strong,
+.connection-add-copy strong {
+  display: block;
+  overflow: hidden;
+  color: #fff;
+  font-size: 1.15rem;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-add-copy strong {
+  font-size: 1rem;
+}
+
+.connection-identity-copy span,
+.connection-add-copy span {
+  display: block;
+  overflow: hidden;
+  color: rgba(255, 255, 255, .72);
+  font-size: .92rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.connection-actions {
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.connection-actions .ui.button,
+.connection-add-row .ui.button {
+  flex: 0 0 auto;
+  margin: 0;
+}
+
+.connections-add-list {
+  display: grid;
+  gap: 10px;
+}
+
+.connection-add-row {
+  padding: 12px;
+}
+
+.connection-discord {
+  --connection-brand: #5865f2;
+}
+
+.connection-twitch {
+  --connection-brand: #9146ff;
+}
+
+.connection-osu {
+  --connection-brand: #ff66aa;
+}
+
+@media only screen and (max-width: 991px) {
+  .connections-card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media only screen and (max-width: 500px) {
+  .connection-add-row {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}
+
 /* Modern button hover effects (exclude dropdowns to prevent menu misalignment) */
 .ui.button:not(.disabled):not(.loading):not(.dropdown) {
   transition: transform 0.15s ease,

--- a/web/templates/settings/connections.html
+++ b/web/templates/settings/connections.html
@@ -14,7 +14,7 @@ MinPrivileges=2
       {{ template "settingsSidebar" . }}
       <div class="twelve wide column">
         <div class="ui segment">
-          {{ $q := qb "SELECT discord_account_id IS NOT NULL AS discord_linked, discord_account_id, twitch_account_id IS NOT NULL AS twitch_linked, twitch_account_id, twitch_username, official_osu_user_id IS NOT NULL AS osu_linked, official_osu_user_id, official_osu_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
+          {{ $q := qb "SELECT discord_account_id IS NOT NULL AS discord_linked, IFNULL(CAST(discord_account_id AS CHAR), '') AS discord_account_id, twitch_account_id IS NOT NULL AS twitch_linked, IFNULL(twitch_account_id, '') AS twitch_account_id, IFNULL(twitch_username, '') AS twitch_username, official_osu_user_id IS NOT NULL AS osu_linked, IFNULL(CAST(official_osu_user_id AS CHAR), '') AS official_osu_user_id, IFNULL(official_osu_username, '') AS official_osu_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
 
           {{ if or $q.discord_linked.Bool $q.twitch_linked.Bool $q.osu_linked.Bool }}
             <div class="connections-section">

--- a/web/templates/settings/connections.html
+++ b/web/templates/settings/connections.html
@@ -14,89 +14,176 @@ MinPrivileges=2
       {{ template "settingsSidebar" . }}
       <div class="twelve wide column">
         <div class="ui segment">
-          {{ $q := qb "SELECT discord_account_id IS NOT NULL AS discord_linked, twitch_account_id IS NOT NULL AS twitch_linked, twitch_username, official_osu_user_id IS NOT NULL AS osu_linked, official_osu_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
-          {{ if $q.discord_linked.Bool }}
-            <p>
-              {{ .T "Your Discord account is already linked with us. If you wish to unlink your Discord, please use the button below." }}
-            </p>
-            <button id="unlink-discord" tabindex="1" class="ui blue button">
-              <i class="fa-brands fa-discord"></i>
-              {{ .T "Unlink Discord" }}
-            </button>
-          {{ else }}
-            <p>
-              <b>
-                {{ .T "Link your Discord account" }}
-              </b>
-            </p>
-            <p>
-              {{ .T "Linking your Discord account will allow you to access extra features related to interacting in our Discord server. For example, linking your Discord account will allow you to automatically receive roles such as Akatsuki+ and Akatsuki Champion." }}
-            </p>
-            <p class="centered">
-              <a
-                tabindex="1"
-                class="ui blue button"
-                href="/link-discord">
-                <i class="fa-brands fa-discord"></i>
-                {{ .T "Link Discord" }}
-              </a>
-            </p>
+          {{ $q := qb "SELECT discord_account_id IS NOT NULL AS discord_linked, discord_account_id, twitch_account_id IS NOT NULL AS twitch_linked, twitch_account_id, twitch_username, official_osu_user_id IS NOT NULL AS osu_linked, official_osu_user_id, official_osu_username FROM users WHERE id = ? LIMIT 1" .Context.User.ID }}
+
+          {{ if or $q.discord_linked.Bool $q.twitch_linked.Bool $q.osu_linked.Bool }}
+            <div class="connections-section">
+              <h3>{{ .T "Linked accounts" }}</h3>
+              <div class="connections-card-grid">
+                {{ if $q.discord_linked.Bool }}
+                  <div class="connection-card connection-discord">
+                    <div class="connection-card-header">
+                      <div class="connection-provider">
+                        <span class="connection-provider-mark">
+                          <i class="fa-brands fa-discord"></i>
+                        </span>
+                        <span>{{ .T "Discord" }}</span>
+                      </div>
+                      <span class="connection-status">{{ .T "Linked" }}</span>
+                    </div>
+                    <div class="connection-identity">
+                      <div class="connection-avatar connection-provider-avatar">
+                        <i class="fa-brands fa-discord"></i>
+                      </div>
+                      <div class="connection-identity-copy">
+                        <strong>{{ .T "Discord account" }}</strong>
+                        <span>{{ .T "Discord ID %s" $q.discord_account_id.String }}</span>
+                      </div>
+                    </div>
+                    <div class="connection-actions">
+                      <a
+                        class="ui blue button"
+                        href="https://discord.com/users/{{ $q.discord_account_id.String }}"
+                        rel="noopener noreferrer"
+                        target="_blank">
+                        {{ .T "View profile" }}
+                      </a>
+                      <button id="unlink-discord" tabindex="1" class="ui button">
+                        {{ .T "Unlink" }}
+                      </button>
+                    </div>
+                  </div>
+                {{ end }}
+
+                {{ if $q.twitch_linked.Bool }}
+                  <div class="connection-card connection-twitch">
+                    <div class="connection-card-header">
+                      <div class="connection-provider">
+                        <span class="connection-provider-mark">
+                          <i class="fa-brands fa-twitch"></i>
+                        </span>
+                        <span>{{ .T "Twitch" }}</span>
+                      </div>
+                      <span class="connection-status">{{ .T "Linked" }}</span>
+                    </div>
+                    <div class="connection-identity">
+                      <div class="connection-avatar connection-provider-avatar">
+                        <i class="fa-brands fa-twitch"></i>
+                      </div>
+                      <div class="connection-identity-copy">
+                        <strong>{{ $q.twitch_username.String }}</strong>
+                        <span>@{{ $q.twitch_username.String }}</span>
+                      </div>
+                    </div>
+                    <div class="connection-actions">
+                      <a
+                        class="ui purple button"
+                        href="https://www.twitch.tv/{{ $q.twitch_username.String }}"
+                        rel="noopener noreferrer"
+                        target="_blank">
+                        {{ .T "View profile" }}
+                      </a>
+                      <button id="unlink-twitch" tabindex="1" class="ui button">
+                        {{ .T "Unlink" }}
+                      </button>
+                    </div>
+                  </div>
+                {{ end }}
+
+                {{ if $q.osu_linked.Bool }}
+                  <div class="connection-card connection-osu">
+                    <div class="connection-card-header">
+                      <div class="connection-provider">
+                        <span class="connection-provider-mark">
+                          <img src="/static/images/logos/osu-logo.png" alt="">
+                        </span>
+                        <span>{{ .T "osu!" }}</span>
+                      </div>
+                      <span class="connection-status">{{ .T "Linked" }}</span>
+                    </div>
+                    <div class="connection-identity">
+                      <div class="connection-avatar">
+                        <img src="https://a.ppy.sh/{{ $q.official_osu_user_id.String }}" alt="">
+                      </div>
+                      <div class="connection-identity-copy">
+                        <strong>{{ $q.official_osu_username.String }}</strong>
+                        <span>{{ .T "osu! ID %s" $q.official_osu_user_id.String }}</span>
+                      </div>
+                    </div>
+                    <div class="connection-actions">
+                      <a
+                        class="ui osu button"
+                        href="https://osu.ppy.sh/users/{{ $q.official_osu_user_id.String }}"
+                        rel="noopener noreferrer"
+                        target="_blank">
+                        {{ .T "View profile" }}
+                      </a>
+                      <button id="unlink-osu" tabindex="1" class="ui button">
+                        {{ .T "Unlink" }}
+                      </button>
+                    </div>
+                  </div>
+                {{ end }}
+              </div>
+            </div>
           {{ end }}
-          <div class="ui divider"></div>
-          {{ if $q.twitch_linked.Bool }}
-            <p>
-              {{ .T "Your Twitch account is already linked with us as %s. If you wish to unlink your Twitch account, please use the button below." $q.twitch_username }}
-            </p>
-            <button id="unlink-twitch" tabindex="1" class="ui purple button">
-              <i class="fa-brands fa-twitch"></i>
-              {{ .T "Unlink Twitch" }}
-            </button>
-          {{ else }}
-            <p>
-              <b>
-                {{ .T "Link your Twitch account" }}
-              </b>
-            </p>
-            <p>
-              {{ .T "Linking your Twitch account lets Aika forward beatmap links from your Twitch chat to you in-game while you are streaming and online on Akatsuki." }}
-            </p>
-            <p class="centered">
-              <a
-                tabindex="1"
-                class="ui purple button"
-                href="/link-twitch">
-                <i class="fa-brands fa-twitch"></i>
-                {{ .T "Link Twitch" }}
-              </a>
-            </p>
-          {{ end }}
-          <div class="ui divider"></div>
-          {{ if $q.osu_linked.Bool }}
-            <p>
-              {{ .T "Your official osu! account is already linked with us as %s. If you wish to unlink your official osu! account, please use the button below." $q.official_osu_username }}
-            </p>
-            <button id="unlink-osu" tabindex="1" class="ui osu button">
-              <img src="/static/images/logos/osu-logo.png" alt="" class="osu-logo-icon">
-              {{ .T "Unlink osu!" }}
-            </button>
-          {{ else }}
-            <p>
-              <b>
-                {{ .T "Link your official osu! account" }}
-              </b>
-            </p>
-            <p>
-              {{ .T "Linking your official osu! account lets Akatsuki verify your identity on osu.ppy.sh for future account connection features." }}
-            </p>
-            <p class="centered">
-              <a
-                tabindex="1"
-                class="ui osu button"
-                href="/link-osu">
-                <img src="/static/images/logos/osu-logo.png" alt="" class="osu-logo-icon">
-                {{ .T "Link osu!" }}
-              </a>
-            </p>
+
+          {{ if not (and $q.discord_linked.Bool $q.twitch_linked.Bool $q.osu_linked.Bool) }}
+            <div class="connections-section">
+              <h3>{{ .T "Add a connection" }}</h3>
+              <div class="connections-add-list">
+                {{ if not $q.discord_linked.Bool }}
+                  <div class="connection-add-row connection-discord">
+                    <div class="connection-provider">
+                      <span class="connection-provider-mark">
+                        <i class="fa-brands fa-discord"></i>
+                      </span>
+                      <div class="connection-add-copy">
+                        <strong>{{ .T "Discord" }}</strong>
+                        <span>{{ .T "Sync Discord roles and perks." }}</span>
+                      </div>
+                    </div>
+                    <a tabindex="1" class="ui blue button" href="/link-discord">
+                      {{ .T "Link Discord" }}
+                    </a>
+                  </div>
+                {{ end }}
+
+                {{ if not $q.twitch_linked.Bool }}
+                  <div class="connection-add-row connection-twitch">
+                    <div class="connection-provider">
+                      <span class="connection-provider-mark">
+                        <i class="fa-brands fa-twitch"></i>
+                      </span>
+                      <div class="connection-add-copy">
+                        <strong>{{ .T "Twitch" }}</strong>
+                        <span>{{ .T "Forward Twitch chat map links in-game." }}</span>
+                      </div>
+                    </div>
+                    <a tabindex="1" class="ui purple button" href="/link-twitch">
+                      {{ .T "Link Twitch" }}
+                    </a>
+                  </div>
+                {{ end }}
+
+                {{ if not $q.osu_linked.Bool }}
+                  <div class="connection-add-row connection-osu">
+                    <div class="connection-provider">
+                      <span class="connection-provider-mark">
+                        <img src="/static/images/logos/osu-logo.png" alt="">
+                      </span>
+                      <div class="connection-add-copy">
+                        <strong>{{ .T "osu!" }}</strong>
+                        <span>{{ .T "Verify your official osu! identity." }}</span>
+                      </div>
+                    </div>
+                    <a tabindex="1" class="ui osu button" href="/link-osu">
+                      {{ .T "Link osu!" }}
+                    </a>
+                  </div>
+                {{ end }}
+              </div>
+            </div>
           {{ end }}
         </div>
       </div>


### PR DESCRIPTION
## Summary
- replace the paragraph-heavy connections page with Proposal A from the mockup
- show linked accounts as provider-branded cards with available username/ID and profile actions
- show unlinked providers as compact add-connection rows

## Notes
- This uses the provider data Hanayo already has today. Discord and Twitch linked cards use provider-logo placeholders because we do not currently cache their provider avatar metadata.
- The local design mockup file was not included in this PR.

## Tests
- git diff --check
- go test ./app/handlers/connections ./app/usecases/templates
- go build

`go build ./...` still fails on the existing `app/middleware/blacklist` package because it has no `main` function; the root `go build` passes.